### PR TITLE
Use `README.md` in the activerecord-session_store.gemspec

### DIFF
--- a/activerecord-session_store.gemspec
+++ b/activerecord-session_store.gemspec
@@ -11,11 +11,11 @@ Gem::Specification.new do |s|
   s.email       = 'david@loudthinking.com'
   s.homepage    = 'http://www.rubyonrails.org'
 
-  s.files        = Dir['CHANGELOG.md', 'MIT-LICENSE', 'README.rdoc', 'lib/**/*']
+  s.files        = Dir['CHANGELOG.md', 'MIT-LICENSE', 'README.md', 'lib/**/*']
   s.require_path = 'lib'
 
-  s.extra_rdoc_files = %w( README.rdoc )
-  s.rdoc_options.concat ['--main',  'README.rdoc']
+  s.extra_rdoc_files = %w( README.md )
+  s.rdoc_options.concat ['--main',  'README.md']
 
   s.add_dependency('activerecord', '~> 4.0.0.beta')
   s.add_dependency('actionpack', '~> 4.0.0.beta')


### PR DESCRIPTION
`bundle install` shows following messages and bundler does not install the activerecord-session_store gem.

``` ruby
activerecord-session_store at <gem location> did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
["README.rdoc"] are not files
```
