### PR TITLE
Remove attr_accessible from ActiveRecord::SessionStore::Session

### DIFF
--- a/lib/active_record/session_store/session.rb
+++ b/lib/active_record/session_store/session.rb
@@ -10,8 +10,6 @@ module ActiveRecord
       cattr_accessor :data_column_name
       self.data_column_name = 'data'
 
-      attr_accessible :session_id, :data, :marshaled_data
-
       before_save :marshal_data!
       before_save :raise_on_session_data_overflow!
 
@@ -52,7 +50,7 @@ module ActiveRecord
           end
       end
 
-      def initialize(attributes = nil, options = {})
+      def initialize(attributes = nil)
         @data = nil
         super
       end

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -23,12 +23,6 @@ module ActiveRecord
         assert_equal 'sessions', Session.table_name
       end
 
-      def test_accessible_attributes
-        assert Session.accessible_attributes.include?(:session_id)
-        assert Session.accessible_attributes.include?(:data)
-        assert Session.accessible_attributes.include?(:marshaled_data)
-      end
-
       def test_create_table!
         assert !Session.table_exists?
         Session.create_table!


### PR DESCRIPTION
In Rails 4.0, attr_accessible is extracted into protected_attributes gem package. Additionally, mass_assignment_options is removed from ActiveRecord rails/rails@2d7ae1b0 , so attr_accessible option should be removed.
