### PR TITLE
Use logger.quielty instead of silence

### DIFF
--- a/lib/action_dispatch/session/active_record_store.rb
+++ b/lib/action_dispatch/session/active_record_store.rb
@@ -61,7 +61,7 @@ module ActionDispatch
 
       private
         def get_session(env, sid)
-          ActiveRecord::Base.silence do
+          ActiveRecord::Base.logger.quietly do
             unless sid and session = @@session_class.find_by_session_id(sid)
               # If the sid was nil or if there is no pre-existing session under the sid,
               # force the generation of a new sid and associate a new session associated with the new sid
@@ -74,7 +74,7 @@ module ActionDispatch
         end
 
         def set_session(env, sid, session_data, options)
-          ActiveRecord::Base.silence do
+          ActiveRecord::Base.logger.quietly do
             record = get_session_model(env, sid)
             record.data = session_data
             return false unless record.save
@@ -92,7 +92,7 @@ module ActionDispatch
 
         def destroy_session(env, session_id, options)
           if sid = current_session_id(env)
-            ActiveRecord::Base.silence do
+            ActiveRecord::Base.logger.quietly do
               get_session_model(env, sid).destroy
               env[SESSION_RECORD_KEY] = nil
             end


### PR DESCRIPTION
Use ActiveRecord::Base.logger.quietly instead of ActiveRecord::Base.silence, because the later is not thread safe.

Signed-off-by: Shin-ichiro OGAWA <rust.stnard+git@gmail.com>
