### PR TITLE
Threading issue when redefining find_by_session_id

### DIFF
--- a/lib/active_record/session_store/session.rb
+++ b/lib/active_record/session_store/session.rb
@@ -20,7 +20,7 @@ module ActiveRecord
 
         # Hook to set up sessid compatibility.
         def find_by_session_id(session_id)
-          setup_sessid_compatibility!
+          Thread.exclusive { setup_sessid_compatibility! }
           find_by_session_id(session_id)
         end
 


### PR DESCRIPTION
Running under JRuby exposes a problem with the way method redefinition happens with the `find_by_session_id` method.  This patch wraps that with an exclusive block ensuring that one thread doesnt remove a method from underneath another.
