### PR TITLE
Fix warning message. It seems that the source :rubygems was deprecated.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec
 


### PR DESCRIPTION
When I executed `bundle update`, I found the following warning.

```
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
```
