### PR TITLE
session_id should have a unique index

### DIFF
--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -6,7 +6,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration
       t.timestamps
     end
 
-    add_index :<%= session_table_name %>, :session_id
+    add_index :<%= session_table_name %>, :session_id, :unique => true
     add_index :<%= session_table_name %>, :updated_at
   end
 end


### PR DESCRIPTION
The session migration generator creates the sessions table without a unique index on session_id, whereas `ActiveRecord::SessionStore::Session.create_table!` creates it with a unique index.

This change makes them consistent in having a unique index on session_id.
