### PR TITLE
Preserve Session construction compatibility without attr_accessible

### DIFF
--- a/lib/active_record/session_store/session.rb
+++ b/lib/active_record/session_store/session.rb
@@ -53,6 +53,12 @@ module ActiveRecord
       def initialize(attributes = nil)
         @data = nil
         super
+        unless attributes.nil?
+          if self.class.method_defined?(:session_id=)
+            self.session_id = attributes[:session_id]
+          end
+          self.data = attributes[:data]
+        end
       end
 
       # Lazy-unmarshal session state.

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -72,6 +72,18 @@ module ActiveRecord
         s = Session.new
         assert !s.loaded?, 'session is not loaded'
       end
+
+      def test_construct_with_mass_assignemnt
+        Session.create_table!
+        session_id = "11"
+        data = "data"
+        s = session_klass.new(:data => data, :session_id => session_id)
+        assert_equal session_id, s.session_id
+        assert_equal data, s.data
+      ensure
+        Session.drop_table!
+      end
+
     end
   end
 end


### PR DESCRIPTION
Fixes rails/activerecord-session_store#6