### PR TITLE
Fix thread safety logging issue

### DIFF
--- a/lib/action_dispatch/session/active_record_store.rb
+++ b/lib/action_dispatch/session/active_record_store.rb
@@ -61,29 +61,25 @@ module ActionDispatch
 
       private
         def get_session(env, sid)
-          ActiveRecord::Base.logger.quietly do
-            unless sid and session = @@session_class.find_by_session_id(sid)
-              # If the sid was nil or if there is no pre-existing session under the sid,
-              # force the generation of a new sid and associate a new session associated with the new sid
-              sid = generate_sid
-              session = @@session_class.new(:session_id => sid, :data => {})
-            end
-            env[SESSION_RECORD_KEY] = session
-            [sid, session.data]
+          unless sid and session = @@session_class.find_by_session_id(sid)
+            # If the sid was nil or if there is no pre-existing session under the sid,
+            # force the generation of a new sid and associate a new session associated with the new sid
+            sid = generate_sid
+            session = @@session_class.new(:session_id => sid, :data => {})
           end
+          env[SESSION_RECORD_KEY] = session
+          [sid, session.data]
         end
 
         def set_session(env, sid, session_data, options)
-          ActiveRecord::Base.logger.quietly do
-            record = get_session_model(env, sid)
-            record.data = session_data
-            return false unless record.save
+          record = get_session_model(env, sid)
+          record.data = session_data
+          return false unless record.save
 
-            session_data = record.data
-            if session_data && session_data.respond_to?(:each_value)
-              session_data.each_value do |obj|
-                obj.clear_association_cache if obj.respond_to?(:clear_association_cache)
-              end
+          session_data = record.data
+          if session_data && session_data.respond_to?(:each_value)
+            session_data.each_value do |obj|
+              obj.clear_association_cache if obj.respond_to?(:clear_association_cache)
             end
           end
 
@@ -92,10 +88,8 @@ module ActionDispatch
 
         def destroy_session(env, session_id, options)
           if sid = current_session_id(env)
-            ActiveRecord::Base.logger.quietly do
-              get_session_model(env, sid).destroy
-              env[SESSION_RECORD_KEY] = nil
-            end
+            get_session_model(env, sid).destroy
+            env[SESSION_RECORD_KEY] = nil
           end
 
           generate_sid unless options[:drop]


### PR DESCRIPTION
closes #19. (Sep 13, 2013)

It took a few days to track down this production issue where logging stops after a few seconds. The problem occurs with a combination of activerecord-session_store, pg and rails_12factor under a threaded web server (puma).

We didn't know specifically where the issue came from, hence:

* Rails: https://github.com/rails/rails/issues/14031
* Puma: https://github.com/puma/puma/issues/465
* lograge: https://github.com/roidrage/lograge/issues/65
* Heroku forums: https://discussion.heroku.com/t/rails-logging-stops-a-few-minutes-after-boot-threadsafety/455

An example app to reproduce this issue is here:
https://github.com/GetJobber/logging_example

Is there an alternative to `logger.quietly` that is thread-safe or should we just remove it?
