### PR TITLE
Remove `:github` from gem installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Installation
 
 Include this gem into your Gemfile:
 
-    gem 'activerecord-session_store', github: 'rails/activerecord-session_store'
+    gem 'activerecord-session_store'
 
 Run the migration generator:
 


### PR DESCRIPTION
The gem is available on rubygems.org. Any reason you would want users to install directly from GitHub?
