### PR TITLE
Add ActiveRecord::SessionStore::VERSION

### DIFF
--- a/activerecord-session_store.gemspec
+++ b/activerecord-session_store.gemspec
@@ -1,7 +1,9 @@
+require File.expand_path('../lib/active_record/session_store/version', __FILE__)
+
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'activerecord-session_store'
-  s.version     = '0.1.0'
+  s.version     = ActiveRecord::SessionStore::VERSION
   s.summary     = 'An Action Dispatch session store backed by an Active Record class.'
 
   s.required_ruby_version = '>= 1.9.3'

--- a/lib/active_record/session_store.rb
+++ b/lib/active_record/session_store.rb
@@ -1,3 +1,4 @@
+require 'active_record/session_store/version'
 require 'action_dispatch/session/active_record_store'
 
 module ActiveRecord

--- a/lib/active_record/session_store/version.rb
+++ b/lib/active_record/session_store/version.rb
@@ -1,0 +1,5 @@
+module ActiveRecord
+  module SessionStore
+    VERSION = '0.1.0'
+  end
+end


### PR DESCRIPTION
I notice other gems hosted under github.com/rails also don't have this constant, so this might be some policy I'm unaware of, but I wanted to add a monkey patch to our application to work around https://github.com/rails/activerecord-session_store/pull/22. I tend to put a big `if`-clause around such patches to make sure they won't break an upgrade of the gem they're patching. Not having the version of the gem available in some constant makes this really hard.