### PR TITLE
Add :key option to session config example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Run the migration generator:
 Then, set your session store in `config/initializers/session_store.rb`:
 
 ```ruby
-Foo::Application.config.session_store :active_record_store
+Foo::Application.config.session_store :active_record_store, :key => '_foo_session'
 ```
 
 Configuration


### PR DESCRIPTION
I have experienced strange behavior with the flash in Rails 4.1.1 when not defining the `:key` on the `config.session_store`. The strange behavior includes the flash not being set, is lost, or not appearing in the correct context (not on the following action but one sometimes two actions later).

I've yet to pinpoint _why_ this is happening and will open an issue/pr when I do.