### PR TITLE
Rake task to trim old sessions

### DIFF
--- a/lib/tasks/database.rake
+++ b/lib/tasks/database.rake
@@ -11,4 +11,10 @@ namespace 'db:sessions' do
   task :clear => [:environment, 'db:load_config'] do
     ActiveRecord::Base.connection.execute "DELETE FROM #{ActiveRecord::SessionStore::Session.table_name}"
   end
+
+  desc "Trim old sessions from the table (default: > 30 days)"
+  task :trim => [:environment, 'db:load_config'] do
+    cutoff_period = (ENV['SESSION_DAYS_TRIM_THRESHOLD'] || 30).to_i.days.ago
+    ActiveRecord::Base.connection.execute("DELETE FROM #{ActiveRecord::SessionStore::Session.table_name} WHERE updated_at < '#{cutoff_period}'")
+  end
 end

--- a/test/tasks/database_rake_test.rb
+++ b/test/tasks/database_rake_test.rb
@@ -1,0 +1,50 @@
+require 'helper'
+require 'rake'
+
+module ActiveRecord
+  module SessionStore
+    class DatabaseRakeTest < ActiveSupport::TestCase
+
+      class AddTimestampsToSession < ActiveRecord::Migration
+        def change
+          add_column Session.table_name, :created_at, :datetime
+          add_column Session.table_name, :updated_at, :datetime
+        end
+      end
+
+      def setup
+        Session.drop_table! if Session.table_exists?
+        Session.create_table!
+
+        silence_stream(STDOUT) { AddTimestampsToSession.new.exec_migration(ActiveRecord::Base.connection, :up) }
+        Session.connection.schema_cache.clear!
+        Session.reset_column_information
+
+        Rake.application.rake_require "tasks/database"
+        Rake::Task.define_task(:environment)
+        Rake::Task.define_task('db:load_config')
+      end
+
+      def teardown
+        Session.drop_table! if Session.table_exists?
+        Session.connection.schema_cache.clear!
+        Session.reset_column_information
+      end
+
+      def test_trim_task
+        cutoff_period = 30.days.ago
+
+        Session.create(:data => 'session to be cleared', :updated_at => cutoff_period - 5.minutes)
+        recent_session = Session.create(:data => 'session to be kept', :updated_at => cutoff_period + 5.minutes)
+
+        Rake.application.invoke_task 'db:sessions:trim'
+
+        old_session_count = Session.where("updated_at < ?", cutoff_period).count
+        retained_session = Session.find(recent_session.id)
+
+        assert_equal 0, old_session_count
+        assert_equal retained_session, recent_session
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hello,

This PR adds a rake task to delete old sessions from the table, without clearing the entire table.

Many thanks,
Oli