### PR TITLE
Update railtie.rb

### DIFF
--- a/lib/active_record/session_store/railtie.rb
+++ b/lib/active_record/session_store/railtie.rb
@@ -3,7 +3,7 @@ require 'rails/railtie'
 module ActiveRecord
   module SessionStore
     class Railtie < Rails::Railtie
-      rake_tasks { load "tasks/database.rake" }
+      rake_tasks { load File.expand_path("../../../tasks/database.rake", __FILE__) }
     end
   end
 end


### PR DESCRIPTION
I'm working on a Rails 4.1.5 project that had a database.rake file in the lib/tasks folder.  Because the path specified in this load was non-specific Rails was finding and loading the lib/tasks/database.rake file in my Rails application twice.

This change make the path is specific to the database.rake file in this GEM to prevent double loading of Rails application rake tasks that might use the same filename.