### PR TITLE
Fix initialize signature to match ActiveRecord::Base

### DIFF
--- a/lib/active_record/session_store/session.rb
+++ b/lib/active_record/session_store/session.rb
@@ -59,7 +59,7 @@ module ActiveRecord
           end
       end
 
-      def initialize(attributes = nil)
+      def initialize(*)
         @data = nil
         super
       end


### PR DESCRIPTION
I'm running into an error where I'm unable to call `create!` on a `Session` when including the Protected Attributes gem (latest 1.1.3). The Protected Attributes gem adds an options hash as the second argument to `Session.new`, but the initialize method for `Session` only accepts a single argument.  

```
Failure/Error: session_to_delete = ActiveRecord::SessionStore::Session.create!(:session_id => "abc7f90d0c2190a161d46af004c6c78c", :data => "")

ArgumentError:
  wrong number of arguments calling `initialize` (2 for 1)
# ~/.rvm/gems/jruby-1.7.9@apply/gems/activerecord-4.0.13/lib/active_record/inheritance.rb:31:in `new'
# ~/.rvm/gems/jruby-1.7.9@apply/gems/protected_attributes-1.1.3/lib/active_record/mass_assignment_security/validations.rb:15:in `create!'
# ./spec/runners/purge_sessions_runner_spec.rb:10:in `(root)'
```

Since the `Session` object extends `ActiveRecord::Base` which has an initialize method with a signature like `def initialize(attributes = nil, options = {})` ([reference](https://github.com/rails/rails/blob/4-0-stable/activerecord/lib/active_record/core.rb#L170)), and the Protected Attributes gem assumes it should call any wrapped objects with `new(attributes, options)` ([reference](https://github.com/rails/protected_attributes/blob/master/lib/active_record/mass_assignment_security/validations.rb#L15)), it makes sense to have the signature for the `Session` object match.

This could be due to an unusual setup with jruby 1.7.9, rails 4.0.13, activerecord-session_store 0.1.1, and protected_attributes 1.1.3, but this seems like a pretty safe change.

Note: It looks like `ActiveRecord` drops the options hash in Rails 5, but this gem requires `4.0.0 <= active_record < 5`.