### PR TITLE
Use generic namespace rather than App-specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Run the migration generator:
 Then, set your session store in `config/initializers/session_store.rb`:
 
 ```ruby
-MyApp::Application.config.session_store :active_record_store, :key => '_my_app_session'
+Rails.application.config.session_store :active_record_store, :key => '_my_app_session'
 ```
 
 Configuration


### PR DESCRIPTION
We may as well use the generic path to set configuration in the README as per the Rails core documentation.

It provides one less change the user has to make and also allows the renaming of applications down the road very slightly easier (no need to change "MyApp" to the new name).

I've tested this in a live app and it's functioning correctly. Let me know what you think.

Thanks. :)