### PR TITLE
Use the update Rack constant for RACK_SESSION_OPTIONS

### DIFF
--- a/lib/action_dispatch/session/active_record_store.rb
+++ b/lib/action_dispatch/session/active_record_store.rb
@@ -58,7 +58,12 @@ module ActionDispatch
       cattr_accessor :session_class
 
       SESSION_RECORD_KEY = 'rack.session.record'
-      ENV_SESSION_OPTIONS_KEY = Rack::Session::Abstract::ENV_SESSION_OPTIONS_KEY
+
+      if Rack.const_defined?('RACK_SESSION_OPTIONS')
+        ENV_SESSION_OPTIONS_KEY = Rack::RACK_SESSION_OPTIONS
+      else
+        ENV_SESSION_OPTIONS_KEY = Rack::Session::Abstract::ENV_SESSION_OPTIONS_KEY
+      end
 
       private
         def get_session(env, sid)


### PR DESCRIPTION
The new Rack behavior moves the `RACK_SESSION_OPTIONS_KEY` into the `Rack` namespace, under the constant `Rack::RACK_SESSION_OPTIONS`.

This PR simply checks if that constant is defined and uses it over assuming the old path exists.