### PR TITLE
Rails 5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ rvm:
   - ruby-head
 
 gemfile:
-  - gemfiles/4.0.gemfile
-  - gemfiles/4.1.gemfile
-  - gemfiles/4.2.gemfile
   - gemfiles/edge.gemfile
 
 notifications:
@@ -22,13 +19,6 @@ before_install:
 
 matrix:
   fast_finish: true
-  exclude:
-    - rvm: 1.9.3
-      gemfile: gemfiles/edge.gemfile
-    - rvm: 2.0
-      gemfile: gemfiles/edge.gemfile
-    - rvm: 2.1
-      gemfile: gemfiles/edge.gemfile
   allow_failures:
     - rvm: ruby-head
     - gemfile: gemfiles/edge.gemfile

--- a/Appraisals
+++ b/Appraisals
@@ -11,6 +11,7 @@ appraise "edge" do
     gem "actionpack"
     gem "activerecord"
     gem "railties"
+    gem "rack", github: "rack/rack"
   end
 
   gem "arel", github: "rails/arel"

--- a/gemfiles/edge.gemfile
+++ b/gemfiles/edge.gemfile
@@ -6,6 +6,7 @@ git "https://github.com/rails/rails.git" do
   gem "actionpack"
   gem "activerecord"
   gem "railties"
+  gem "rack", :github => "rack/rack"
 end
 
 gem "arel", :github => "rails/arel"

--- a/lib/action_dispatch/session/active_record_store.rb
+++ b/lib/action_dispatch/session/active_record_store.rb
@@ -111,8 +111,7 @@ module ActionDispatch
           logger.silence_logger do
             session = @@session_class.find_by_session_id(id) if id
             if session.nil?
-              id = generate_sid
-              session = @@session_class.new(:session_id => id, :data => {})
+              session = @@session_class.new(:session_id => generate_sid, :data => {})
               session.save
             end
             if request.env[ENV_SESSION_OPTIONS_KEY][:id].nil?

--- a/lib/action_dispatch/session/active_record_store.rb
+++ b/lib/action_dispatch/session/active_record_store.rb
@@ -58,7 +58,12 @@ module ActionDispatch
       cattr_accessor :session_class
 
       SESSION_RECORD_KEY = 'rack.session.record'
-      ENV_SESSION_OPTIONS_KEY = Rack::Session::Abstract::ENV_SESSION_OPTIONS_KEY
+
+      if Rack.const_defined?('RACK_SESSION_OPTIONS')
+        ENV_SESSION_OPTIONS_KEY = Rack::RACK_SESSION_OPTIONS
+      else
+        ENV_SESSION_OPTIONS_KEY = Rack::Session::Abstract::ENV_SESSION_OPTIONS_KEY
+      end
 
       private
         def get_session(env, sid)

--- a/lib/active_record/session_store.rb
+++ b/lib/active_record/session_store.rb
@@ -13,12 +13,12 @@ module ActiveRecord
       end
 
       def drop_table!
-        connection.schema_cache.clear_table_cache!(table_name)
+        connection.schema_cache.clear_data_source_cache!(table_name)
         connection.drop_table table_name
       end
 
       def create_table!
-        connection.schema_cache.clear_table_cache!(table_name)
+        connection.schema_cache.clear_data_source_cache!(table_name)
         connection.create_table(table_name) do |t|
           t.string session_id_column, :limit => 255
           t.text data_column_name

--- a/test/action_controller_test.rb
+++ b/test/action_controller_test.rb
@@ -13,11 +13,11 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
     end
 
     def get_session_value
-      render :text => "foo: #{session[:foo].inspect}"
+      render :plain => "foo: #{session[:foo].inspect}"
     end
 
     def get_session_id
-      render :text => "#{request.session.id}"
+      render :plain => "#{request.session.id}"
     end
 
     def call_reset_session
@@ -29,7 +29,7 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
     end
 
     def renew
-      env["rack.session.options"][:renew] = true
+      session.options[:renew] = true
       session[:foo] = "baz"
       head :ok
     end
@@ -52,7 +52,7 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
           assert_response :success
           assert_equal 'foo: "bar"', response.body
 
-          get '/set_session_value', :foo => "baz"
+          get '/set_session_value', params: { :foo => "baz" }
           assert_response :success
           assert cookies['_session_id']
 
@@ -92,7 +92,7 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
 
   def test_calling_reset_session_twice_does_not_raise_errors
     with_test_route_set do
-      get '/call_reset_session', :twice => "true"
+      get '/call_reset_session', params: { :twice => "true" }
       assert_response :success
 
       get '/get_session_value'
@@ -189,7 +189,7 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
 
       reset!
 
-      get '/get_session_value', :_session_id => session_id
+      get '/get_session_value', params: { :_session_id => session_id }
       assert_response :success
       assert_equal 'foo: nil', response.body
       assert_not_equal session_id, cookies['_session_id']
@@ -210,11 +210,11 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
 
       reset!
 
-      get '/set_session_value', :_session_id => session_id, :foo => "baz"
+      get '/set_session_value', params: { :_session_id => session_id, :foo => "baz" }
       assert_response :success
       assert_equal session_id, cookies['_session_id']
 
-      get '/get_session_value', :_session_id => session_id
+      get '/get_session_value', params: { :_session_id => session_id }
       assert_response :success
       assert_equal 'foo: "baz"', response.body
       assert_equal session_id, cookies['_session_id']
@@ -240,7 +240,7 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
   def test_incoming_invalid_session_id_via_parameter_should_be_ignored
     with_test_route_set(:cookie_only => false) do
       open_session do |sess|
-        sess.get '/set_session_value', :_session_id => 'INVALID'
+        sess.get '/set_session_value', params: { :_session_id => 'INVALID' }
         new_session_id = sess.cookies['_session_id']
         assert_not_equal 'INVALID', new_session_id
 

--- a/test/action_controller_test.rb
+++ b/test/action_controller_test.rb
@@ -17,7 +17,7 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
     end
 
     def get_session_id
-      render :text => "#{request.session_options[:id]}"
+      render :text => "#{request.session.id}"
     end
 
     def call_reset_session

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -25,12 +25,12 @@ class ActionDispatch::IntegrationTest < ActiveSupport::TestCase
 
   def self.build_app(routes = nil)
     RoutedRackApp.new(routes || ActionDispatch::Routing::RouteSet.new) do |middleware|
-      middleware.use "ActionDispatch::DebugExceptions"
-      middleware.use "ActionDispatch::Callbacks"
-      middleware.use "ActionDispatch::ParamsParser"
-      middleware.use "ActionDispatch::Cookies"
-      middleware.use "ActionDispatch::Flash"
-      middleware.use "Rack::Head"
+      middleware.use ActionDispatch::DebugExceptions
+      middleware.use ActionDispatch::Callbacks
+      middleware.use ActionDispatch::ParamsParser
+      middleware.use ActionDispatch::Cookies
+      middleware.use ActionDispatch::Flash
+      middleware.use Rack::Head
       yield(middleware) if block_given?
     end
   end
@@ -47,7 +47,7 @@ class ActionDispatch::IntegrationTest < ActiveSupport::TestCase
 
         @app = self.class.build_app(set) do |middleware|
           middleware.use ActionDispatch::Session::ActiveRecordStore, options.reverse_merge(:key => '_session_id')
-          middleware.delete "ActionDispatch::ShowExceptions"
+          middleware.delete ActionDispatch::ShowExceptions
         end
 
         yield

--- a/test/logger_silencer_test.rb
+++ b/test/logger_silencer_test.rb
@@ -10,7 +10,7 @@ class LoggerSilencerTest < ActionDispatch::IntegrationTest
     end
 
     def get_session_value
-      render :text => "foo: #{session[:foo].inspect}"
+      render :plain => "foo: #{session[:foo].inspect}"
     end
   end
 


### PR DESCRIPTION
This is a follow up on #57 and closes #55.
It brakes Rails 4 support because a few methods had to be renamed.