### PR TITLE
setup_sessid_compatibility! after app initialized instead.

### DIFF
--- a/lib/active_record/session_store/railtie.rb
+++ b/lib/active_record/session_store/railtie.rb
@@ -4,6 +4,10 @@ module ActiveRecord
   module SessionStore
     class Railtie < Rails::Railtie
       rake_tasks { load File.expand_path("../../../tasks/database.rake", __FILE__) }
+      config.after_initialize do
+        # Hook to set up sessid compatibility.
+        Session.send(:setup_sessid_compatibility!)
+      end
     end
   end
 end

--- a/lib/active_record/session_store/session.rb
+++ b/lib/active_record/session_store/session.rb
@@ -27,12 +27,6 @@ module ActiveRecord
           @data_column_size_limit ||= columns_hash[data_column_name].limit
         end
 
-        # Hook to set up sessid compatibility.
-        def find_by_session_id(session_id)
-          Thread.exclusive { setup_sessid_compatibility! }
-          find_by_session_id(session_id)
-        end
-
         private
           def session_id_column
             'session_id'

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -43,6 +43,7 @@ module ActiveRecord
           end
         end
         klass.create_table!
+        klass.send(:setup_sessid_compatibility!)
 
         assert klass.columns_hash['sessid'], 'sessid column exists'
         session = klass.new(:data => 'hello')


### PR DESCRIPTION
In Ruby 2.3.0, `Thread.exclusive` is deprecated and it's a bad
idea to do this lazily anyway. Instead, we should do this during
initialization or after initialization. This way, we don't have to
care about thread safety because no one would/should load the
application in multiple threads.