### PR TITLE
Add support to change session_id via session_options

### DIFF
--- a/lib/action_dispatch/session/active_record_store.rb
+++ b/lib/action_dispatch/session/active_record_store.rb
@@ -80,7 +80,7 @@ module ActionDispatch
 
       def write_session(request, sid, session_data, options)
         logger.silence_logger do
-          record = get_session_model(request, sid, generate_id: false)
+          record = get_session_model(request, sid, false)
           record.data = session_data
           return false unless record.save
 
@@ -119,7 +119,7 @@ module ActionDispatch
         end
       end
 
-      def get_session_model(request, id, generate_id: true)
+      def get_session_model(request, id, generate_id = true)
         logger.silence_logger do
           model = @@session_class.find_by_session_id(id)
           if !model

--- a/lib/action_dispatch/session/active_record_store.rb
+++ b/lib/action_dispatch/session/active_record_store.rb
@@ -112,6 +112,7 @@ module ActionDispatch
             if options[:renew]
               new_model = @@session_class.new(:session_id => new_sid, :data => data)
               new_model.save
+              request.session_options[:id] = new_sid
               request.env[SESSION_RECORD_KEY] = new_model
             end
             new_sid
@@ -127,12 +128,7 @@ module ActionDispatch
             model = @@session_class.new(:session_id => id, :data => {})
             model.save
           end
-          if request.env[ENV_SESSION_OPTIONS_KEY][:id].nil?
-            request.env[SESSION_RECORD_KEY] = model
-          else
-            request.env[SESSION_RECORD_KEY] ||= model
-          end
-          model
+          request.env[SESSION_RECORD_KEY] = model
         end
       end
 

--- a/lib/action_dispatch/session/active_record_store.rb
+++ b/lib/action_dispatch/session/active_record_store.rb
@@ -80,7 +80,7 @@ module ActionDispatch
 
       def write_session(request, sid, session_data, options)
         logger.silence_logger do
-          record = get_session_model(request, sid)
+          record = get_session_model(request, sid, generate_id: false)
           record.data = session_data
           return false unless record.save
 
@@ -91,7 +91,7 @@ module ActionDispatch
             end
           end
 
-          sid
+          record.session_id
         end
       end
 
@@ -119,11 +119,11 @@ module ActionDispatch
         end
       end
 
-      def get_session_model(request, id)
+      def get_session_model(request, id, generate_id: true)
         logger.silence_logger do
           model = @@session_class.find_by_session_id(id)
           if !model
-            id = generate_sid
+            id = generate_sid if generate_id
             model = @@session_class.new(:session_id => id, :data => {})
             model.save
           end

--- a/lib/action_dispatch/session/legacy_support.rb
+++ b/lib/action_dispatch/session/legacy_support.rb
@@ -35,7 +35,8 @@ module ActionDispatch
         generate_sid unless options[:drop]
       end
 
-      def get_session_model(request, sid)
+      def get_session_model(request, sid, generate_id = false)
+        sid = generate_sid if generate_id
         if request.env[self.class::ENV_SESSION_OPTIONS_KEY][:id].nil?
           request.env[self.class::SESSION_RECORD_KEY] = find_session(sid)
         else

--- a/lib/action_dispatch/session/legacy_support.rb
+++ b/lib/action_dispatch/session/legacy_support.rb
@@ -37,11 +37,8 @@ module ActionDispatch
 
       def get_session_model(request, sid, generate_id = false)
         sid = generate_sid if generate_id
-        if request.env[self.class::ENV_SESSION_OPTIONS_KEY][:id].nil?
-          request.env[self.class::SESSION_RECORD_KEY] = find_session(sid)
-        else
-          request.env[self.class::SESSION_RECORD_KEY] ||= find_session(sid)
-        end
+        model = find_session(sid)
+        request.env[self.class::SESSION_RECORD_KEY] = model
       end
 
       def find_session(id)

--- a/test/action_controller_test.rb
+++ b/test/action_controller_test.rb
@@ -39,7 +39,7 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
 
     def change_session_id
       session[:foo] = 'bar'
-      request.session_options[:id] = params[:session_id]
+      request.session_options[:id] = params[:session_id] || 'id'
       head :ok
     end
 
@@ -108,6 +108,22 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_record_available_in_env
+    with_test_route_set do
+      get '/set_session_value'
+      record = request.env[record_key]
+
+      assert_equal record.session_id, session.id
+      assert_equal session.to_hash, record.data
+
+      get '/change_session_id'
+      record = request.env[record_key]
+
+      assert_equal record.session_id, session.id
+      assert_equal session.to_hash, record.data
+    end
+  end
+
   def test_changing_session_id
     with_test_route_set do
       session_id = 'id'
@@ -117,10 +133,19 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
       else
         get '/change_session_id', params: { session_id: session_id }
       end
+      record = request.env[record_key]
+
+      assert_equal record.session_id, session.id
+      assert_equal session.to_hash, record.data
 
       assert_equal session[:foo], 'bar'
 
-      get '/get_session_id'
+      get '/get_session_value'
+      record = request.env[record_key]
+
+      assert_equal record.session_id, session.id
+      assert_equal session.to_hash, record.data
+
       assert_equal session_id, session.id
       assert_equal session[:foo], 'bar'
     end
@@ -308,5 +333,11 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
       get '/set_session_value'
       assert_response :success
     end
+  end
+
+  private
+
+  def record_key
+    ActionDispatch::Session::ActiveRecordStore::SESSION_RECORD_KEY
   end
 end

--- a/test/action_controller_test.rb
+++ b/test/action_controller_test.rb
@@ -37,6 +37,12 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
       head :ok
     end
 
+    def change_session_id
+      session[:foo] = 'bar'
+      request.session_options[:id] = params[:session_id]
+      head :ok
+    end
+
     def renew
       request.env["rack.session.options"][:renew] = true
       head :ok
@@ -99,6 +105,24 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
       get '/get_session_value'
       assert_response :success
       assert_equal 'foo: nil', response.body
+    end
+  end
+
+  def test_changing_session_id
+    with_test_route_set do
+      session_id = 'id'
+
+      if ActiveRecord::VERSION::MAJOR == 4
+        get '/change_session_id', session_id: session_id
+      else
+        get '/change_session_id', params: { session_id: session_id }
+      end
+
+      assert_equal session[:foo], 'bar'
+
+      get '/get_session_id'
+      assert_equal session_id, session.id
+      assert_equal session[:foo], 'bar'
     end
   end
 


### PR DESCRIPTION
This PR basically adds support to change the `session_id` via `request.session_options`. The problem with the current implementation is that if there's a session already loaded and we try to change the `session_id` via `request.session_options[:id] = "new session id"`, a new record will be created with a completely different id, however the cookie will still point to the old `session_id`.

For example:

``` ruby
# FIRST REQUEST
session[:user] = 1 # creates record in the DB assigning random id. E.g. 1010
request.session_options[:id] = '2020'
```

Before the end of the request the session is saved in the database with a different ID (E.g. 3030) since the gem couldn't find any session_id == 2020. However, the main problem is that the `session_id` used in the cookie is now set to 2020.

A subsequent request would be sending a cookie with session_id = 2020, resulting in a unexpected state.

`request.session_options[:id] = '2020'` is probably something that we shouldn't do in the middle of the request but it was something I came across in one of the projects that I work and I kinda of spent some time to find out the problem so I think this could be helpful for other developers.

@gigr @sbfaulkner
