### PR TITLE
Do not use 'return false' in AR callbacks for compatibility with Rails 5

### DIFF
--- a/lib/active_record/session_store/session.rb
+++ b/lib/active_record/session_store/session.rb
@@ -80,7 +80,10 @@ module ActiveRecord
 
       private
         def serialize_data!
-          return unless loaded?
+          unless loaded?
+            return false if Rails::VERSION::MAJOR < 5
+            throw :abort
+          end
           write_attribute(@@data_column_name, self.class.serialize(data))
         end
 
@@ -88,7 +91,10 @@ module ActiveRecord
         # larger than the data storage column. Raises
         # ActionController::SessionOverflowError.
         def raise_on_session_data_overflow!
-          return unless loaded?
+          unless loaded?
+            return false if Rails::VERSION::MAJOR < 5
+            throw :abort
+          end
           limit = self.class.data_column_size_limit
           if limit and read_attribute(@@data_column_name).size > limit
             raise ActionController::SessionOverflowError

--- a/lib/active_record/session_store/session.rb
+++ b/lib/active_record/session_store/session.rb
@@ -80,7 +80,7 @@ module ActiveRecord
 
       private
         def serialize_data!
-          return false unless loaded?
+          return unless loaded?
           write_attribute(@@data_column_name, self.class.serialize(data))
         end
 
@@ -88,7 +88,7 @@ module ActiveRecord
         # larger than the data storage column. Raises
         # ActionController::SessionOverflowError.
         def raise_on_session_data_overflow!
-          return false unless loaded?
+          return unless loaded?
           limit = self.class.data_column_size_limit
           if limit and read_attribute(@@data_column_name).size > limit
             raise ActionController::SessionOverflowError


### PR DESCRIPTION
The current implementation lead to `DEPRECATION WARNING`s under Rails 5 and ultimately prevented records from being saved. If I interpret the code right, the `return false` statements are not meant for halting the whole saving chain but just mean to exit the method. I've replaced them with a simple `return` and everything appears to work.

Thanks a bunch for considering this.