### PR TITLE
Test with nokogiri that works with Ruby < 2.1 in Travis CI

### DIFF
--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "actionpack", "~> 4.2.0"
 gem "activerecord", "~> 4.2.0"
+gem "nokogiri", "< 1.7" if RUBY_VERSION < "2.1"
 gem "railties", "~> 4.2.0"
 
 gemspec :path => "../"


### PR DESCRIPTION
Fix a build error in Travis CI.

This PR will fix a following build error.

```sh
Gem::InstallError: nokogiri requires Ruby version >= 2.1.0.
Installing activerecord 4.2.8
An error occurred while installing nokogiri (1.7.0.1), and Bundler cannot continue.
Make sure that `gem install nokogiri -v '1.7.0.1'` succeeds before bundling.
```

Refer: https://travis-ci.org/rails/activerecord-session_store/jobs/211003494
