### PR TITLE
Remove the `supports_migrations?` check:

### DIFF
--- a/lib/tasks/database.rake
+++ b/lib/tasks/database.rake
@@ -1,7 +1,6 @@
 namespace 'db:sessions' do
   desc "Creates a sessions migration for use with ActiveRecord::SessionStore"
   task :create => [:environment, 'db:load_config'] do
-    raise 'Task unavailable to this database (no migration support)' unless ActiveRecord::Base.connection.supports_migrations?
     Rails.application.load_generators
     require 'generators/active_record/session_migration_generator'
     ActiveRecord::Generators::SessionMigrationGenerator.start [ ENV['MIGRATION'] || 'add_sessions_table' ]


### PR DESCRIPTION
Remove the `supports_migrations?` check:

- This method is deprecated as of Rails 5.1. All tested databases seems to supports migrations since at least rails/rails@a4fc93c
- Ref rails/rails#28172