### PR TITLE
No upper-bound dependency for AR/AP/Railties

### DIFF
--- a/activerecord-session_store.gemspec
+++ b/activerecord-session_store.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w( README.md )
   s.rdoc_options.concat ['--main',  'README.md']
 
-  s.add_dependency('activerecord', '>= 4.0', '< 5.2')
-  s.add_dependency('actionpack', '>= 4.0', '< 5.2')
-  s.add_dependency('railties', '>= 4.0', '< 5.2')
+  s.add_dependency('activerecord', '>= 4.0')
+  s.add_dependency('actionpack', '>= 4.0')
+  s.add_dependency('railties', '>= 4.0')
   s.add_dependency('rack', '>= 1.5.2', '< 3')
   s.add_dependency('multi_json', '~> 1.11', '>= 1.11.2')
 


### PR DESCRIPTION
I don't think much is gained by having an upper-limit dependency on AP/AR/Railties. It just forces you guys to make a release for every minor version of this gem. Im not sure if that actually helps us in any way.