### PR TITLE
[CHORE] Fix Rails 6 deprecations

### DIFF
--- a/test/action_controller_test.rb
+++ b/test/action_controller_test.rb
@@ -187,7 +187,7 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
 
       get '/get_session_value'
       assert_response :success
-      assert_equal nil, headers['Set-Cookie'], "should not resend the cookie again if session_id cookie is already exists"
+      assert_nil headers['Set-Cookie'], "should not resend the cookie again if session_id cookie is already exists"
     end
   end
 

--- a/test/destroy_session_test.rb
+++ b/test/destroy_session_test.rb
@@ -27,7 +27,7 @@ if ActiveRecord::VERSION::MAJOR > 4
           s.destroy
 
           renewed_session_model = req.env[record_key]
-          assert_equal nil, renewed_session_model.data['rails']
+          assert_nil renewed_session_model.data['rails']
         end
 
         def test_destroy_with_renew

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -38,10 +38,11 @@ class ActionDispatch::IntegrationTest < ActiveSupport::TestCase
 
     def with_test_route_set(options = {})
       controller_namespace = self.class.to_s.underscore
+      actions = %w[set_session_value get_session_value call_reset_session renew get_session_id]
 
       with_routing do |set|
         set.draw do
-          get ':action', :controller => "#{controller_namespace}/test"
+          actions.each { |action| get action, controller: "#{controller_namespace}/test" }
         end
 
         @app = self.class.build_app(set) do |middleware|


### PR DESCRIPTION
After #120 I noticed there were some deprecation warnings for Rails 6:

1. `DEPRECATION WARNING: Using a dynamic :action segment in a route is deprecated and will be removed in Rails 6.0`
2. `DEPRECATED: Use assert_nil if expecting nil`