### PR TITLE
Use lazy-load hook:

### DIFF
--- a/lib/active_record/session_store.rb
+++ b/lib/active_record/session_store.rb
@@ -108,11 +108,14 @@ module ActiveRecord
   end
 end
 
-require 'active_record/session_store/session'
+ActiveSupport.on_load(:active_record) do
+  require 'active_record/session_store/session'
+  ActionDispatch::Session::ActiveRecordStore.session_class = ActiveRecord::SessionStore::Session
+end
+
 require 'active_record/session_store/sql_bypass'
 require 'active_record/session_store/railtie' if defined?(Rails)
 
-ActionDispatch::Session::ActiveRecordStore.session_class = ActiveRecord::SessionStore::Session
 Logger.send :include, ActiveRecord::SessionStore::Extension::LoggerSilencer
 
 begin


### PR DESCRIPTION
Use lazy-load hook:

- When requiring `active_record/session_store/session`, it will load the `ActiveRecord::Base` [class](https://github.com/rails/activerecord-session_store/blob/a170dd4016208b9ce45cb77f2d946d2d7ef8064e/lib/active_record/session_store/session.rb#L7) which triggers all lazy load hooks at the wrong time