### PR TITLE
Improved performance of delete_session in case there is none

### DIFF
--- a/lib/action_dispatch/session/active_record_store.rb
+++ b/lib/action_dispatch/session/active_record_store.rb
@@ -98,7 +98,7 @@ module ActionDispatch
       def delete_session(request, session_id, options)
         logger.silence_logger do
           if sid = current_session_id(request)
-            if model = get_session_model(request, sid)
+            if model = @@session_class.find_by_session_id(sid)
               data = model.data
               model.destroy
             end


### PR DESCRIPTION
As stated in #130 this improves the performance of `delete_session` in case there is no existing session.

The `delete_session` method uses the [`get_session_model` method](https://github.com/rails/activerecord-session_store/blob/3e0147c74f862dc9a3600a8b11c980d9d43897a1/lib/action_dispatch/session/active_record_store.rb#L101) which creates a [new instance if no existing is found](https://github.com/rails/activerecord-session_store/blob/3e0147c74f862dc9a3600a8b11c980d9d43897a1/lib/action_dispatch/session/active_record_store.rb#L125-L134) only to [destroy it afterwards](https://github.com/rails/activerecord-session_store/blob/3e0147c74f862dc9a3600a8b11c980d9d43897a1/lib/action_dispatch/session/active_record_store.rb#L101-L107). Using `@@session_class.find_by_session_id(id)` instead (which is `get_session_model` doing too) works fine in our env and avoids the overhead.