### PR TITLE
Fixed: uninitialized constant ActiveRecord::VERSION (NameError).

### DIFF
--- a/lib/action_dispatch/session/active_record_store.rb
+++ b/lib/action_dispatch/session/active_record_store.rb
@@ -148,7 +148,6 @@ module ActionDispatch
   end
 end
 
-require 'active_record'
 if ActiveRecord::VERSION::MAJOR == 4
   require 'action_dispatch/session/legacy_support'
   ActionDispatch::Session::ActiveRecordStore.send(:include, ActionDispatch::Session::LegacySupport)

--- a/lib/action_dispatch/session/active_record_store.rb
+++ b/lib/action_dispatch/session/active_record_store.rb
@@ -148,6 +148,7 @@ module ActionDispatch
   end
 end
 
+require 'active_record'
 if ActiveRecord::VERSION::MAJOR == 4
   require 'action_dispatch/session/legacy_support'
   ActionDispatch::Session::ActiveRecordStore.send(:include, ActionDispatch::Session::LegacySupport)

--- a/lib/active_record/session_store.rb
+++ b/lib/active_record/session_store.rb
@@ -1,3 +1,4 @@
+require 'active_record'
 require 'active_record/session_store/version'
 require 'action_dispatch/session/active_record_store'
 require "active_record/session_store/extension/logger_silencer"


### PR DESCRIPTION
Hi there,

I stumbled across an issue when using `activerecord-session_store` via bundlers inline functionality:

```
/path/to/gems/ruby-2.4.2/gems/activerecord-session_store-1.1.0/lib/action_dispatch/session/active_record_store.rb:151:in `<top (required)>': uninitialized constant ActiveRecord::VERSION (NameError)
  from /path/to/gems/ruby-2.4.2/gems/activerecord-session_store-1.1.0/lib/active_record/session_store.rb:2:in `require'
  from /path/to/gems/ruby-2.4.2/gems/activerecord-session_store-1.1.0/lib/active_record/session_store.rb:2:in `<top (required)>'
  from /path/to/gems/ruby-2.4.2/gems/activerecord-session_store-1.1.0/lib/activerecord/session_store.rb:1:in `require'
  from /path/to/gems/ruby-2.4.2/gems/activerecord-session_store-1.1.0/lib/activerecord/session_store.rb:1:in `<top (required)>'
  from /path/to/gems/ruby-2.4.2/gems/bundler-1.16.2/lib/bundler/runtime.rb:95:in `require'
  from /path/to/gems/ruby-2.4.2/gems/bundler-1.16.2/lib/bundler/runtime.rb:95:in `rescue in block in require'
  from /path/to/gems/ruby-2.4.2/gems/bundler-1.16.2/lib/bundler/runtime.rb:72:in `block in require'
  from /path/to/gems/ruby-2.4.2/gems/bundler-1.16.2/lib/bundler/runtime.rb:65:in `each'
  from /path/to/gems/ruby-2.4.2/gems/bundler-1.16.2/lib/bundler/runtime.rb:65:in `require'
  from /path/to/gems/ruby-2.4.2/gems/bundler-1.16.2/lib/bundler/inline.rb:70:in `gemfile'
  from ./demo.rb:5:in `<main>'
```

I made [a demo repo](https://github.com/thorsteneckel/activerecord-session_store_bundler_inline_issue_demo) for you to reproduce it. Just run the `demo.rb` file.

The fix is fairly simple: Just `require 'active_record'` before accessing the constant.