### PR TITLE
Optionally sign or encrypt cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,24 @@ been updated in the last 30 days. The 30 days cutoff can be changed using the
 Configuration
 --------------
 
+A cookie is used to identify the appropriate ActiveRecord record.
+By default this cookie is in cleartext.
+You may optionally configure this cookie to be signed or encrypted. For example, at the end of `config/application.rb`:
+
+```ruby
+ActiveRecord::SessionStore::Session.sign_cookie = true
+ActiveRecord::SessionStore::Session.encrypt_cookie = true
+```
+
+Setting these configuration values has the following behaviors:
+
+| `sign_cookie` | `encrypt_cookie` | Behavior         |
+| ------------- | ---------------- | ---------------- |
+| false         | false            | Cleartext cookie |
+| false         | true             | Encrypted cookie |
+| true          | false            | Signed cookie    |
+| true          | true             | Encrypted cookie |
+
 Disable fallback to use insecure session by providing the option
 `secure_session_only` when setting up the session store.
 

--- a/lib/action_dispatch/session/active_record_store.rb
+++ b/lib/action_dispatch/session/active_record_store.rb
@@ -9,6 +9,22 @@ module ActionDispatch
     # provided, but any object duck-typing to an Active Record Session class
     # with text +session_id+ and +data+ attributes is sufficient.
     #
+    # A cookie is used to identify the appropriate ActiveRecord record.
+    # By default this cookie is in cleartext.
+    # You may optionally configure this cookie to be signed or encrypted.
+    # For example, at the end of `config/application.rb`:
+    #
+    # ActiveRecord::SessionStore::Session.sign_cookie = true
+    # ActiveRecord::SessionStore::Session.encrypt_cookie = true
+    #
+    # Setting these configuration values has the following behaviors:
+    # sign_cookie   encrypt_cookie   Behavior
+    # ------------- ---------------- ----------------
+    # false         false            Cleartext cookie
+    # false         true             Encrypted cookie
+    # true          false            Signed cookie
+    # true          true             Encrypted cookie
+    #
     # The default assumes a +sessions+ tables with columns:
     #   +id+ (numeric primary key),
     #   +session_id+ (string, usually varchar; maximum length is 255), and
@@ -79,6 +95,60 @@ module ActionDispatch
           end
           request.env[SESSION_RECORD_KEY] = session
           [sid, session.data]
+        end
+      end
+
+      def cookie_is_signed_or_encrypted?
+        ActiveRecord::SessionStore::Session.sign_cookie || ActiveRecord::SessionStore::Session.encrypt_cookie
+      end
+
+      # Inspired by ActionDispatch::Session::CookieStore
+      # https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
+      # (ideally should by DRY in ActionPack by migrating to ActionDispatch::Session::AbstractStore)
+      # (noting that ActionDispatch::Session::CookieStore does not currently respect :cookie_only)
+      def extract_session_id(req)
+        sid = stale_session_check! do
+          sid_str = unpacked_cookie_data(req)
+          sid_str && Rack::Session::SessionId.new(sid_str)
+        end
+
+        # Inspired by Rack::Session::Abstract::Persisted
+        # https://github.com/rack/rack/blob/master/lib/rack/session/abstract/id.rb
+        sid ||= Rack::Session::SessionId.new(req.params[@key]) unless @cookie_only || ! req.params[@key]
+        sid
+      end
+
+      # Inspired by ActionDispatch::Session::CookieStore
+      # https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/session/cookie_store.rb
+      # (ideally should by DRY in ActionPack by migrating to ActionDispatch::Session::AbstractStore)
+      def unpacked_cookie_data(req)
+
+        req.fetch_header("action_dispatch.request.unsigned_session_cookie") do |k|
+          v = stale_session_check! do
+            get_cookie(req) || nil  # not empty string
+          end
+          req.set_header k, v
+        end
+      end
+
+      # Duplicated from ActionDispatch::Session::CookieStore
+      # (ideally should by DRY in ActionPack by migrating to ActionDispatch::Session::AbstractStore)
+      def set_cookie(request, session_id, cookie)
+        cookie_jar(request)[@key] = cookie
+      end
+
+      # Duplicated from ActionDispatch::Session::CookieStore
+      # (ideally should by DRY in ActionPack by migrating to ActionDispatch::Session::AbstractStore)
+      def get_cookie(req)
+        cookie_jar(req)[@key]
+      end
+
+      # Inspired from ActionDispatch::Session::CookieStore
+      def cookie_jar(request)
+        if cookie_is_signed_or_encrypted?
+          request.cookie_jar.signed_or_encrypted
+        else
+          request.cookie_jar
         end
       end
 

--- a/lib/active_record/session_store.rb
+++ b/lib/active_record/session_store.rb
@@ -10,7 +10,9 @@ module ActiveRecord
     autoload :Session, 'active_record/session_store/session'
 
     module ClassMethods # :nodoc:
+      mattr_accessor :encrypt_cookie
       mattr_accessor :serializer
+      mattr_accessor :sign_cookie
 
       def serialize(data)
         serializer_class.dump(data) if data

--- a/test/action_controller_test.rb
+++ b/test/action_controller_test.rb
@@ -1,4 +1,5 @@
 require 'helper'
+require 'active_support/messages/rotation_configuration'
 
 class ActionControllerTest < ActionDispatch::IntegrationTest
   class SessionWithSaveCounter < ActiveRecord::SessionStore::Session
@@ -30,6 +31,20 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
 
     self.find_by_session_id_calls = 0
   end
+
+  SESSION_SECRET = "b3c631c314c0bbca50c1b2843150fe33"
+  SESSION_SALT   = "signed or encrypted cookie"
+
+  Generator = ActiveSupport::KeyGenerator.new(SESSION_SECRET, iterations: 1000)
+  Rotations = ActiveSupport::Messages::RotationConfiguration.new
+
+  Verifier = ActiveSupport::MessageVerifier.new(
+    Generator.generate_key(SESSION_SALT), serializer: Marshal
+  )
+
+  Encryptor = ActiveSupport::MessageEncryptor.new(
+    Generator.generate_key(SESSION_SALT, 32), cipher: "aes-256-gcm", serializer: Marshal
+  )
 
   class TestController < ActionController::Base
     protect_from_forgery
@@ -68,6 +83,9 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
   def setup
     ActionDispatch::Session::ActiveRecordStore.session_class.drop_table! rescue nil
     ActionDispatch::Session::ActiveRecordStore.session_class.create_table!
+
+    ActiveRecord::SessionStore::Session.sign_cookie = false
+    ActiveRecord::SessionStore::Session.encrypt_cookie = false
   end
 
   %w{ session sql_bypass }.each do |class_name|
@@ -182,7 +200,7 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
       get '/set_session_value'
       assert_response :success
       assert cookies['_session_id']
-      session_cookie = cookies.get_cookie('_session_id')
+      session_cookie = cookies.get_cookie("_session_id")
 
       get '/call_reset_session'
       assert_response :success
@@ -215,6 +233,69 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
       get '/get_session_id'
       assert_response :success
       assert_equal session_id, response.body, "should be able to read session id without accessing the session hash"
+    end
+  end
+
+  def test_signed_cookie
+    ActiveRecord::SessionStore::Session.sign_cookie = true
+    with_test_route_set do
+      get '/set_session_value'
+      assert_response :success
+      assert cookies['_session_id']
+      session_id_signed = cookies['_session_id']
+
+      session_id = Verifier.verified(session_id_signed) rescue nil
+
+      get '/get_session_id'
+      assert_response :success
+      assert_equal session_id, response.body, "should be able to read signed session id"
+    end
+  end
+
+  def test_encrypted_cookie
+    ActiveRecord::SessionStore::Session.encrypt_cookie = true
+    with_test_route_set do
+      get '/set_session_value'
+      assert_response :success
+      assert cookies['_session_id']
+      session_id_encrypted = cookies['_session_id']
+      session_id = Encryptor.decrypt_and_verify(session_id_encrypted) rescue nil
+
+      get '/get_session_id'
+      assert_response :success
+      assert_equal session_id, response.body, "should be able to read encrypted session id"
+    end
+  end
+
+  # From https://github.com/rails/rails/blob/main/actionpack/test/dispatch/session/cookie_store_test.rb
+  def test_signed_cookie_disregards_tampered_sessions
+    ActiveRecord::SessionStore::Session.sign_cookie = true
+    with_test_route_set do
+      bad_key = Generator.generate_key(SESSION_SALT).reverse
+
+      verifier = ActiveSupport::MessageVerifier.new(bad_key, serializer: Marshal)
+
+      cookies["_session_id"] = verifier.generate({ "foo" => "bar", "session_id" => "abc" })
+
+      get "/get_session_value"
+
+      assert_response :success
+      assert_equal "foo: nil", response.body
+    end
+  end
+
+  # From https://github.com/rails/rails/blob/main/actionpack/test/dispatch/session/cookie_store_test.rb
+  def test_encrypted_cookie_disregards_tampered_sessions
+    ActiveRecord::SessionStore::Session.encrypt_cookie = true
+    with_test_route_set do
+      encryptor = ActiveSupport::MessageEncryptor.new("A" * 32, cipher: "aes-256-gcm", serializer: Marshal)
+
+      cookies["_session_id"] = encryptor.encrypt_and_sign({ "foo" => "bar", "session_id" => "abc" })
+
+      get "/get_session_value"
+
+      assert_response :success
+      assert_equal "foo: nil", response.body
     end
   end
 
@@ -455,4 +536,34 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  private
+
+    # Overwrite get to send SessionSecret in env hash
+    # Inspired by https://github.com/rails/rails/blob/main/actionpack/test/dispatch/session/cookie_store_test.rb
+    def get(path, **options)
+      options[:headers] ||= {}
+      options[:headers].tap do |config|
+        signed = ActiveRecord::SessionStore::Session.sign_cookie
+        encrypted = ActiveRecord::SessionStore::Session.encrypt_cookie
+
+        if signed || encrypted
+          config["action_dispatch.key_generator"] ||= Generator
+          config["action_dispatch.cookies_rotations"] ||= Rotations
+        end
+
+        if signed && ! encrypted
+          config["action_dispatch.signed_cookie_salt"] = SESSION_SALT
+        elsif encrypted
+          config["action_dispatch.secret_key_base"] = SESSION_SECRET
+
+          config["action_dispatch.encrypted_cookie_cipher"] = "aes-256-gcm"
+          config["action_dispatch.authenticated_encrypted_cookie_salt"] = SESSION_SALT
+          config["action_dispatch.use_authenticated_cookie_encryption"] = true
+        end
+      end
+
+      super
+    end
+
 end

--- a/test/destroy_session_test.rb
+++ b/test/destroy_session_test.rb
@@ -17,6 +17,9 @@ if ActiveRecord::VERSION::MAJOR > 4
           @req = ActionDispatch::Request.empty
           ActionDispatch::Session::ActiveRecordStore.session_class.drop_table! rescue nil
           ActionDispatch::Session::ActiveRecordStore.session_class.create_table!
+
+          ActiveRecord::SessionStore::Session.sign_cookie = false
+          ActiveRecord::SessionStore::Session.encrypt_cookie = false
         end
 
         def record_key

--- a/test/logger_silencer_test.rb
+++ b/test/logger_silencer_test.rb
@@ -19,6 +19,9 @@ class LoggerSilencerTest < ActionDispatch::IntegrationTest
     session_class.drop_table! rescue nil
     session_class.create_table!
     ActionDispatch::Session::ActiveRecordStore.session_class = session_class
+
+    ActiveRecord::SessionStore::Session.sign_cookie = false
+    ActiveRecord::SessionStore::Session.encrypt_cookie = false
   end
 
   %w{ session sql_bypass }.each do |class_name|

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -14,6 +14,9 @@ module ActiveRecord
         Session.drop_table! if Session.table_exists?
         @session_klass = Class.new(Session)
         ActiveRecord::SessionStore::Session.serializer = :json
+
+        ActiveRecord::SessionStore::Session.sign_cookie = false
+        ActiveRecord::SessionStore::Session.encrypt_cookie = false
       end
 
       def test_data_column_name

--- a/test/sql_bypass_test.rb
+++ b/test/sql_bypass_test.rb
@@ -16,6 +16,9 @@ module ActiveRecord
         assert Session.table_exists?
         SqlBypass.drop_table!
         assert !Session.table_exists?
+
+        ActiveRecord::SessionStore::Session.sign_cookie = false
+        ActiveRecord::SessionStore::Session.encrypt_cookie = false
       end
 
       def test_new_record?


### PR DESCRIPTION
This change fixes #48 by optionally signing or encrypting the cookie. Although #48 primarily concerns signing, I also added encryption support for completeness (though as mentioned [here](https://github.com/rails/activerecord-session_store/issues/48#issuecomment-415595383), this is technically not necessary).

Two new configuration parameters are defined: `sign_cookie`, `encrypt_cookie`. Both default to false for backwards compatibility. 

| `sign_cookie` | `encrypt_cookie` | Behavior         |
| ------------- | ---------------- | ---------------- |
| false         | false            | Cleartext cookie |
| false         | true             | Encrypted cookie |
| true          | false            | Signed cookie    |
| true          | true             | Encrypted cookie |

The tests succeed under Rails 4, 5, and 6.
