### PR TITLE
Lock sqlite3 to ~> 1.3.6 on Rails <= 2.5.2, and update Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,11 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.10
-  - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.2.10
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.1
   - ruby-head
 gemfile:
   - gemfiles/rails_4.0.gemfile
@@ -22,15 +23,19 @@ gemfile:
 matrix:
   fast_finish: true
   exclude:
-    - rvm: 2.4.3
+    - rvm: 2.4.5
       gemfile: gemfiles/rails_4.0.gemfile
-    - rvm: 2.5.0
+    - rvm: 2.5.3
+      gemfile: gemfiles/rails_4.0.gemfile
+    - rvm: 2.6.1
       gemfile: gemfiles/rails_4.0.gemfile
     - rvm: ruby-head
       gemfile: gemfiles/rails_4.0.gemfile
-    - rvm: 2.4.3
+    - rvm: 2.4.5
       gemfile: gemfiles/rails_4.1.gemfile
-    - rvm: 2.5.0
+    - rvm: 2.5.3
+      gemfile: gemfiles/rails_4.1.gemfile
+    - rvm: 2.6.1
       gemfile: gemfiles/rails_4.1.gemfile
     - rvm: ruby-head
       gemfile: gemfiles/rails_4.1.gemfile
@@ -58,9 +63,11 @@ matrix:
       gemfile: gemfiles/rails_edge.gemfile
     - rvm: 2.1.10
       gemfile: gemfiles/rails_edge.gemfile
-    - rvm: 2.2.9
+    - rvm: 2.2.10
       gemfile: gemfiles/rails_edge.gemfile
-    - rvm: 2.3.6
+    - rvm: 2.3.8
+      gemfile: gemfiles/rails_edge.gemfile
+    - rvm: 2.4.5
       gemfile: gemfiles/rails_edge.gemfile
   allow_failures:
     - rvm: ruby-head

--- a/activerecord-session_store.gemspec
+++ b/activerecord-session_store.gemspec
@@ -26,5 +26,4 @@ Gem::Specification.new do |s|
   s.add_dependency('multi_json', '~> 1.11', '>= 1.11.2')
 
   s.add_development_dependency('sqlite3')
-  s.add_development_dependency('appraisal', '~> 2.1.0')
 end

--- a/gemfiles/rails_4.0.gemfile
+++ b/gemfiles/rails_4.0.gemfile
@@ -5,5 +5,6 @@ gem "actionpack", "~> 4.0.0"
 gem "activerecord", "~> 4.0.0"
 gem "railties", "~> 4.0.0"
 gem 'nokogiri', "~> #{nokogiri_ver}.0"
+gem "sqlite3", "~> 1.3.6"
 
 gemspec :path => "../"

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -5,5 +5,6 @@ gem "actionpack", "~> 4.1.0"
 gem "activerecord", "~> 4.1.0"
 gem "railties", "~> 4.1.0"
 gem 'nokogiri', "~> #{nokogiri_ver}.0"
+gem "sqlite3", "~> 1.3.6"
 
 gemspec :path => "../"

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -5,5 +5,6 @@ gem "actionpack", "~> 4.2.0"
 gem "activerecord", "~> 4.2.0"
 gem "railties", "~> 4.2.0"
 gem 'nokogiri', "~> #{nokogiri_ver}.0"
+gem "sqlite3", "~> 1.3.6"
 
 gemspec :path => "../"

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -3,5 +3,6 @@ source "https://rubygems.org"
 gem "actionpack", "~> 5.0.0"
 gem "activerecord", "~> 5.0.0"
 gem "railties", "~> 5.0.0"
+gem "sqlite3", "~> 1.3.6"
 
 gemspec :path => "../"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -3,5 +3,6 @@ source "https://rubygems.org"
 gem "actionpack", "~> 5.1.0"
 gem "activerecord", "~> 5.1.0"
 gem "railties", "~> 5.1.0"
+gem "sqlite3", "~> 1.3.6"
 
 gemspec :path => "../"


### PR DESCRIPTION
This should fix the build failures on `master`, getting the branch ready for release of next version.

This PR includes:

* Lock sqlite3 to ~> 1.3.6 on Rails <= 2.5.2, as those version has `gem "sqlite3", "~> 1.3.6"` in them.
* Remove appraisal from development dependency.
* Add Ruby 2.6.1 to the build matrix.
* Remove Ruby 2.4 from edge Rails since edge Rails now require Ruby 2.5+.