### PR TITLE
Fix backward compatibility issue introduced by #126

### DIFF
--- a/lib/active_record/session_store.rb
+++ b/lib/active_record/session_store.rb
@@ -7,6 +7,8 @@ require 'multi_json'
 
 module ActiveRecord
   module SessionStore
+    autoload :Session, 'active_record/session_store/session'
+
     module ClassMethods # :nodoc:
       mattr_accessor :serializer
 
@@ -111,7 +113,6 @@ end
 
 ActiveSupport.on_load(:active_record) do
   require 'active_record/session_store/session'
-  ActionDispatch::Session::ActiveRecordStore.session_class = ActiveRecord::SessionStore::Session
 end
 
 require 'active_record/session_store/sql_bypass'

--- a/lib/active_record/session_store/session.rb
+++ b/lib/active_record/session_store/session.rb
@@ -103,3 +103,5 @@ module ActiveRecord
     end
   end
 end
+
+ActionDispatch::Session::ActiveRecordStore.session_class = ActiveRecord::SessionStore::Session


### PR DESCRIPTION
- Fixes #142
-  The goal of #126 was to lazily require the 'session.rb' file as
  otherwise, we'd load `Active::Record` base too prematurely during
  the boot process.

  This change had the negative effect of breakin apps that were
  setting configuration on the `Session` **before** the hook was
  getting triggered, thus ending up with a "uninitialized constant"
  error.

  This patches move the `session_class` assignment when loading then
  `session.rb` file as well as autoloading the
  `AR::SessionStore::Session` constant so that application referencing
  it too early will still work.