### PR TITLE
use in_batches method to safely trim large amounts of sessions

### DIFF
--- a/lib/tasks/database.rake
+++ b/lib/tasks/database.rake
@@ -14,8 +14,9 @@ namespace 'db:sessions' do
   desc "Trim old sessions from the table (default: > 30 days)"
   task :trim => [:environment, 'db:load_config'] do
     cutoff_period = (ENV['SESSION_DAYS_TRIM_THRESHOLD'] || 30).to_i.days.ago
-    ActiveRecord::SessionStore::Session.
-      where("updated_at < ?", cutoff_period).
-      delete_all
+    query = ActiveRecord::SessionStore::Session.where("updated_at < ?", cutoff_period)
+    query.in_batches do |relation|
+        relation.delete_all
+    end
   end
 end

--- a/lib/tasks/database.rake
+++ b/lib/tasks/database.rake
@@ -15,8 +15,6 @@ namespace 'db:sessions' do
   task :trim => [:environment, 'db:load_config'] do
     cutoff_period = (ENV['SESSION_DAYS_TRIM_THRESHOLD'] || 30).to_i.days.ago
     query = ActiveRecord::SessionStore::Session.where("updated_at < ?", cutoff_period)
-    query.in_batches do |relation|
-        relation.delete_all
-    end
+    query.in_batches.delete_all
   end
 end


### PR DESCRIPTION
Hello and thank you for this gem!

My organization recently migrated from Rails' default `cookie_store` to `active_record_store`, following the defaults as outlined in your README for setup. We noticed rather quickly that we were seeing far more `sessions` records than expected, roughly 250k-300k/day.

We didn't want to run into a situation where we attempted to delete 9m records in 30 days time, so our first inclination was to lower the `SESSION_DAYS_TRIM_THRESHOLD` variable. However, lowering `SESSION_DAYS_TRIM_THRESHOLD` seemed potentially scary to us, since the `trim` task didn't delete records in batches. Had we lowered it to 1 day, that's still a single SQL DELETE statement for hundreds of thousands of records. We were worried about DB performance, so we overrode the `trim` task to perform the delete in batches.

I figured it would be worthwhile to submit the fix upstream as well, in order to make the delete safer for large amounts of records.