### PR TITLE
Avoid session lookup when ID is nil

### DIFF
--- a/lib/action_dispatch/session/active_record_store.rb
+++ b/lib/action_dispatch/session/active_record_store.rb
@@ -117,7 +117,7 @@ module ActionDispatch
 
       def get_session_model(request, id)
         logger.silence do
-          model = @@session_class.find_by_session_id(id)
+          model = id && @@session_class.find_by_session_id(id)
           if !model
             id = generate_sid
             model = @@session_class.new(:session_id => id, :data => {})
@@ -149,4 +149,3 @@ module ActionDispatch
     end
   end
 end
-


### PR DESCRIPTION
During a request when the session is accessed, [`load_session`](https://github.com/rack/rack/blob/65c4fcd6a0f5217f92a2d84de289cdcfea3fd490/lib/rack/session/abstract/id.rb#L312-L316) will call `find_session` which ends up calling `get_session_model`. When no session cookie is present in the browser, the `id` will be `nil`. Adding `id &&` in this PR avoids an unnecessary database query that would look like:
```ruby
SELECT `sessions`.* FROM `sessions` WHERE `sessions`.`session_id` IS NULL LIMIT 1
````
arguably, if this matched a row, that would be a bug.