### PR TITLE
Use model reference from env when it is available

### DIFF
--- a/lib/action_dispatch/session/active_record_store.rb
+++ b/lib/action_dispatch/session/active_record_store.rb
@@ -117,6 +117,10 @@ module ActionDispatch
 
       def get_session_model(request, id)
         logger.silence do
+          if (model = request.env[SESSION_RECORD_KEY]) && model.session_id == id
+            return model
+          end
+
           model = @@session_class.find_by_session_id(id)
           if !model
             id = generate_sid
@@ -149,4 +153,3 @@ module ActionDispatch
     end
   end
 end
-


### PR DESCRIPTION
The `get_session_model` method will store a reference to the model in `request.env[SESSION_RECORD_KEY]` when the session is loaded. Later on when saving the session, `write_session` calls `get_session_model`, which again calls the active record finder methods to load the model.

In a standard Rails app, this would presumably hit the active record cache and not hit mysql twice, but if the active record cache is invalidated during the request or if `@@session_class#find_by_session_id` was overloaded to do anything else (like perhaps read from an external cache), then the app will end up doing unnecessary work.