### PR TITLE
Optimization: prevent empty COMMIT calls

### DIFF
--- a/lib/action_dispatch/session/active_record_store.rb
+++ b/lib/action_dispatch/session/active_record_store.rb
@@ -86,7 +86,7 @@ module ActionDispatch
         logger.silence do
           record, sid = get_session_model(request, sid)
           record.data = session_data
-          return false if record.changed? and not record.save
+          return sid if record.changed? and not record.save
 
           session_data = record.data
           if session_data && session_data.respond_to?(:each_value)

--- a/lib/action_dispatch/session/active_record_store.rb
+++ b/lib/action_dispatch/session/active_record_store.rb
@@ -86,7 +86,8 @@ module ActionDispatch
         logger.silence do
           record, sid = get_session_model(request, sid)
           record.data = session_data
-          return sid if record.changed? and not record.save
+          return sid unless record.changed? || record.new_record?
+          return false unless record.save
 
           session_data = record.data
           if session_data && session_data.respond_to?(:each_value)

--- a/lib/action_dispatch/session/active_record_store.rb
+++ b/lib/action_dispatch/session/active_record_store.rb
@@ -86,7 +86,7 @@ module ActionDispatch
         logger.silence do
           record, sid = get_session_model(request, sid)
           record.data = session_data
-          return false unless record.save
+          return false if record.changed? and not record.save
 
           session_data = record.data
           if session_data && session_data.respond_to?(:each_value)

--- a/lib/active_record/session_store/session.rb
+++ b/lib/active_record/session_store/session.rb
@@ -68,7 +68,10 @@ module ActiveRecord
         @data ||= self.class.deserialize(read_attribute(@@data_column_name)) || {}
       end
 
-      attr_writer :data
+      def data=(data)
+        attribute_will_change!(@@data_column_name) if data != self.data
+        @data = data
+      end
 
       # Has the session been loaded yet?
       def loaded?

--- a/lib/active_record/session_store/sql_bypass.rb
+++ b/lib/active_record/session_store/sql_bypass.rb
@@ -72,8 +72,6 @@ module ActiveRecord
       attr_accessor :session_id
       alias :new_record? :new_record
 
-      attr_writer :data
-
       # Look for normal and serialized data, self.find_by_session_id's way of
       # telling us to postpone deserializing until the data is requested.
       # We need to handle a normal data attribute in case of a new record.
@@ -83,6 +81,7 @@ module ActiveRecord
         @data           = attributes[:data]
         @serialized_data = attributes[:serialized_data]
         @new_record     = @serialized_data.nil?
+        @data_changed    = false
       end
 
       # Returns true if the record is persisted, i.e. it's not a new record
@@ -106,6 +105,15 @@ module ActiveRecord
         @data
       end
 
+      def data=(data)
+        @data_changed = true if data != self.data
+        @data = data
+      end
+
+      def changed?
+        persisted? && (@retrieved_by != session_id || @data_changed)
+      end
+
       def save
         return false unless loaded?
         serialized_data = self.class.serialize(data)
@@ -113,7 +121,7 @@ module ActiveRecord
 
         if @new_record
           @new_record = false
-          connect.update <<-end_sql, 'Create session'
+          result = connect.update <<-end_sql, 'Create session'
             INSERT INTO #{table_name} (
               #{connect.quote_column_name(session_id_column)},
               #{connect.quote_column_name(data_column)} )
@@ -122,7 +130,7 @@ module ActiveRecord
               #{connect.quote(serialized_data)} )
           end_sql
         else
-          connect.update <<-end_sql, 'Update session'
+          result = connect.update <<-end_sql, 'Update session'
             UPDATE #{table_name}
             SET
               #{connect.quote_column_name(data_column)}=#{connect.quote(serialized_data)},
@@ -130,6 +138,10 @@ module ActiveRecord
             WHERE #{connect.quote_column_name(session_id_column)}=#{connect.quote(@retrieved_by)}
           end_sql
         end
+
+        @retrieved_by = @session_id
+        @data_changed = false
+        result
       end
 
       def destroy

--- a/test/action_controller_test.rb
+++ b/test/action_controller_test.rb
@@ -1,6 +1,21 @@
 require 'helper'
 
 class ActionControllerTest < ActionDispatch::IntegrationTest
+  class SessionWithSaveCounter < ActiveRecord::SessionStore::Session
+    self.table_name = "sessions"
+
+    class << self
+      attr_accessor :save_calls
+    end
+
+    self.save_calls = 0
+
+    def save(*)
+      self.class.save_calls += 1
+      super
+    end
+  end
+
   class SqlBypassWithFindCounter < ActiveRecord::SessionStore::SqlBypass
     self.table_name = "sessions"
 
@@ -212,6 +227,25 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
       get '/get_session_value'
       assert_response :success
       assert_nil headers['Set-Cookie'], "should not resend the cookie again if session_id cookie is already exists"
+    end
+  end
+
+  def test_doesnt_persist_unchanged_session
+    with_session_class SessionWithSaveCounter do
+      with_test_route_set do
+        public_session_id = 'public-session-id'
+        private_session_id = Rack::Session::SessionId.new(public_session_id).private_id
+        SessionWithSaveCounter.create!(:session_id => private_session_id, :data => { 'foo' => 'bar' })
+        cookies['_session_id'] = public_session_id
+
+        SessionWithSaveCounter.save_calls = 0
+
+        get '/get_session_value'
+        assert_response :success
+        assert_equal 'foo: "bar"', response.body
+
+        assert_equal 0, SessionWithSaveCounter.save_calls
+      end
     end
   end
 

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -126,6 +126,17 @@ module ActiveRecord
         assert !s.loaded?, 'session is not loaded'
       end
 
+      def test_data_changes_are_tracked
+        Session.create_table!
+        session_klass.create!(:data => 'world', :session_id => '10')
+        t = session_klass.find_by_session_id('10')
+        assert !t.changed?, 'this session is unchanged!'
+        t.data = 'world'
+        assert !t.changed?, 'this session is unchanged!'
+        t.data = 'hello'
+        assert t.changed?, 'this session has changed!'
+      end
+
       def test_session_can_be_secured
         Session.create_table!
         session_id = 'unsecure'

--- a/test/sql_bypass_test.rb
+++ b/test/sql_bypass_test.rb
@@ -28,6 +28,23 @@ module ActiveRecord
         assert !s.persisted?, 'this is a new record!'
       end
 
+      def test_changed?
+        SqlBypass.create_table! unless Session.table_exists?
+        session_id = 20
+        s = SqlBypass.new :data => 'hello', :session_id => session_id
+        s.save
+        t = SqlBypass.find_by_session_id session_id
+        assert !t.changed?, 'this session is unchanged!'
+        t.data = 'hello'
+        assert !t.changed?, 'this session is unchanged!'
+        t.data = 'world'
+        assert t.changed?, 'this session has changed!'
+        t.save
+        t = SqlBypass.find_by_session_id session_id
+        t.session_id = 30
+        assert t.changed?, 'this session has changed!'
+      end
+
       def test_not_loaded?
         s = SqlBypass.new({})
         assert !s.loaded?, 'it is not loaded'


### PR DESCRIPTION
Prevents `BEGIN COMMIT` empty database calls after each rails request if the session did not change.

Don't know why the `write_session` is called in our app every request, but monkey patching using this logic prevents an empty write at the end of each request.