### PR TITLE
Restore note about custom db class in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ $ rake db:sessions:upgrade
 This rake task is idempotent and can be run multiple times, and session data of
 users will remain intact.
 
+If you are using a custom class for storing your sessions (as described earlier
+in `Configuration`), you need to copy and adapt this task or add a migration
+containing equivalent code.
+
 Please see [#151] for more details.
 
 [#151]: https://github.com/rails/activerecord-session_store/pull/151


### PR DESCRIPTION
I am not sure if this is correct, but it seems to me that the rake task does not work if users are using a custom class (especially if the table name is different).

My suggestion is to restore the old note.