### PR TITLE
Handle custom `session_class` in all rake tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ You must implement these methods:
 * `save`
 * `destroy`
 
+Note that some of the provided [rake tasks](https://github.com/rails/activerecord-session_store/blob/master/lib/tasks/database.rake)
+require additional methods to be implemented:
+
+* `db:sessions:clear` depends on `table_name`
+* `db:sessions:trim` depends on `where` and `delete_all`
+* `db:sessions:upgrade` depends on `secure!`
+
 The example SqlBypass class is a generic SQL session store. You may
 use it as a basis for high-performance database-specific stores.
 
@@ -142,10 +149,6 @@ $ rake db:sessions:upgrade
 
 This rake task is idempotent and can be run multiple times, and session data of
 users will remain intact.
-
-If you are using a custom class for storing your sessions (as described earlier
-in `Configuration`), you need to copy and adapt this task or add a migration
-containing equivalent code.
 
 Please see [#151] for more details.
 

--- a/lib/tasks/database.rake
+++ b/lib/tasks/database.rake
@@ -8,13 +8,13 @@ namespace 'db:sessions' do
 
   desc "Clear the sessions table"
   task :clear => [:environment, 'db:load_config'] do
-    ActiveRecord::Base.connection.execute "TRUNCATE TABLE #{ActiveRecord::SessionStore::Session.table_name}"
+    ActiveRecord::Base.connection.truncate(ActionDispatch::Session::ActiveRecordStore.session_class.table_name)
   end
 
   desc "Trim old sessions from the table (default: > 30 days)"
   task :trim => [:environment, 'db:load_config'] do
     cutoff_period = (ENV['SESSION_DAYS_TRIM_THRESHOLD'] || 30).to_i.days.ago
-    ActiveRecord::SessionStore::Session.
+    ActionDispatch::Session::ActiveRecordStore.session_class.
       where("updated_at < ?", cutoff_period).
       delete_all
   end

--- a/test/tasks/database_rake_test.rb
+++ b/test/tasks/database_rake_test.rb
@@ -63,6 +63,14 @@ module ActiveRecord
         assert Session.find_by_session_id(Rack::Session::SessionId.new("original_session_id").private_id)
         assert Session.find_by_session_id("2::secure_session_id")
       end
+
+      def test_clear_task
+        Session.create!(data: "obsolete")
+
+        Rake.application.invoke_task 'db:sessions:clear'
+
+        assert_equal 0, Session.count
+      end
     end
   end
 end


### PR DESCRIPTION
- Updates all rake tasks to use `ActionDispatch::Session::ActiveRecordStore.session_class`
- Updates README to note which additional methods are needed if you use a custom session class
- Adds a test for an untested rake task

Co-authored-by @marvinthepa