### PR TITLE
Silence update sql log in session upgrade

### DIFF
--- a/lib/active_record/session_store/session.rb
+++ b/lib/active_record/session_store/session.rb
@@ -88,7 +88,9 @@ module ActiveRecord
           # is already private, nothing to do
         else
           session_id_object = Rack::Session::SessionId.new(raw_session_id)
-          update_column(session_id_column, session_id_object.private_id)
+          logger.silence do
+            update_column(session_id_column, session_id_object.private_id)
+          end
         end
       end
 
@@ -111,6 +113,16 @@ module ActiveRecord
           if limit and read_attribute(@@data_column_name).size > limit
             raise ActionController::SessionOverflowError
           end
+        end
+
+        module NilLogger
+          def self.silence
+            yield
+          end
+        end
+
+        def logger
+          ActiveRecord::Base.logger || NilLogger
         end
     end
   end

--- a/lib/tasks/database.rake
+++ b/lib/tasks/database.rake
@@ -21,6 +21,20 @@ namespace 'db:sessions' do
 
   desc "Upgrade current sessions in the database to the secure version"
   task :upgrade => [:environment, 'db:load_config'] do
-    ActionDispatch::Session::ActiveRecordStore.session_class.find_each(&:secure!)
+    logger.silence do
+      ActionDispatch::Session::ActiveRecordStore.session_class.find_each(&:secure!)
+    end
+  end
+
+  private
+
+  module NilLogger
+    def self.silence
+      yield
+    end
+  end
+
+  def logger
+    ActiveRecord::Base.logger || NilLogger
   end
 end

--- a/test/logger_silencer_test.rb
+++ b/test/logger_silencer_test.rb
@@ -44,6 +44,14 @@ class LoggerSilencerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_secure_does_not_log_update_sql
+    with_fake_logger do
+      create_old_session!
+      ActiveRecord::SessionStore::Session.find_each(&:secure!)
+      assert_no_match(/UPDATE/, fake_logger.string)
+    end
+  end
+
   private
 
     def with_logger(logger)
@@ -60,5 +68,13 @@ class LoggerSilencerTest < ActionDispatch::IntegrationTest
 
     def fake_logger
       @fake_logger ||= StringIO.new
+    end
+
+    def create_old_session!
+      session = ActionDispatch::Session::ActiveRecordStore.session_class.new(
+        session_id: "original_session_id",
+        data: "data"
+      )
+      session.save
     end
 end

--- a/test/tasks/database_rake_test.rb
+++ b/test/tasks/database_rake_test.rb
@@ -23,6 +23,7 @@ module ActiveRecord
         Session.reset_column_information
 
         Rake.application.rake_require "tasks/database"
+        Rake::Task.tasks.each(&:reenable)
         Rake::Task.define_task(:environment)
         Rake::Task.define_task("db:load_config")
       end

--- a/test/tasks/logger_silencer_test.rb
+++ b/test/tasks/logger_silencer_test.rb
@@ -1,0 +1,54 @@
+require 'helper'
+require 'rake'
+require 'stringio'
+
+module ActiveRecord
+  module SessionStore
+    class LoggerSilencerTest < ActiveSupport::TestCase
+      def setup
+        Session.drop_table! if Session.table_exists?
+        Session.create_table!
+
+        Rake.application.rake_require 'tasks/database'
+        Rake::Task.tasks.each(&:reenable)
+        Rake::Task.define_task(:environment)
+        Rake::Task.define_task('db:load_config')
+      end
+
+      def teardown
+        Session.drop_table! if Session.table_exists?
+        Session.connection.schema_cache.clear!
+        Session.reset_column_information
+      end
+
+      def test_upgrade_task_does_not_log_sql
+        Session.create!(session_id: 'original_session_id', data: 'data')
+
+        with_fake_logger do
+          Rake.application.invoke_task 'db:sessions:upgrade'
+
+          assert_no_match(/SELECT/, fake_logger.string)
+          assert_no_match(/UPDATE/, fake_logger.string)
+        end
+      end
+
+      private
+
+        def with_logger(logger)
+          original_logger = ActiveRecord::Base.logger
+          ActiveRecord::Base.logger = logger
+          yield
+        ensure
+          ActiveRecord::Base.logger = original_logger
+        end
+
+        def with_fake_logger(&block)
+          with_logger(ActiveSupport::Logger.new(fake_logger), &block)
+        end
+
+        def fake_logger
+          @fake_logger ||= StringIO.new
+        end
+    end
+  end
+end


### PR DESCRIPTION
When upgrading sessions using `secure!` directly or using the rake task
`db:sessions:upgrade`, it would log entries like:

```
  ActiveRecord::SessionStore::Session Load (3.1ms)  SELECT  "sessions".* FROM "s
essions" ORDER BY "sessions"."id" ASC LIMIT 1000
  ActiveRecord::SessionStore::Session Update (1.9ms)  UPDATE "sessions" SET "ses
sion_id" = '2::[some_session_id]'
 WHERE "sessions"."id" = 2
```

Silence logger for these operations to prevent logging session ids.