### PR TITLE
Fix test with rack test 2

### DIFF
--- a/test/action_controller_test.rb
+++ b/test/action_controller_test.rb
@@ -127,7 +127,7 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
       get '/set_session_value'
       assert_response :success
       assert cookies['_session_id']
-      session_cookie = cookies.send(:hash_for)['_session_id']
+      session_cookie = cookies.get_cookie("_session_id")
 
       get '/call_reset_session'
       assert_response :success


### PR DESCRIPTION
As discussed in https://github.com/rails/rails/issues/45467, when using gem rack-test '>= 2.0.0', running tests throws the following error:
```
Error:
ActionControllerTest#test_getting_session_value_after_session_reset:
NoMethodError: undefined method `hash_for' for #<Rack::Test::CookieJar:0x00007fb23bbd7aa0 @default_host="www.example.com", @cookies=[#<Rack::Test::Cookie:0x00007fb23b3b7e10 @default_host="www.example.com", @raw="_session_id=1da458b0817c79f5e30b20428e206e1b", @name="_session_id", @value="1da458b0817c79f5e30b20428e206e1b", @options={"path"=>"/", "HttpOnly"=>nil, "domain"=>"www.example.com"}, @exact_domain_match=true>]>

      session_cookie = cookies.send(:hash_for)['_session_id']
                              ^^^^^
    /REDACTED/activerecord-session_store/test/action_controller_test.rb:130:in `block in test_getting_session_value_after_session_reset'
    /REDACTED/activerecord-session_store/test/helper.rb:53:in `block in with_test_route_set'
    /REDACTED/.rvm/gems/ruby-3.1.2/gems/actionpack-7.0.4/lib/action_dispatch/testing/assertions/routing.rb:174:in `with_routing'
    /REDACTED/activerecord-session_store/test/helper.rb:43:in `with_test_route_set'
    /REDACTED/activerecord-session_store/test/action_controller_test.rb:126:in `test_getting_session_value_after_session_reset'
```
Emulating Rails fixes in https://github.com/rails/rails/pull/45534, this PR changes a single use of `hash_for` to `get_cookie`
