### PR TITLE
Allow Rack 3 in Preparation for Rails 7.1.0

### DIFF
--- a/activerecord-session_store.gemspec
+++ b/activerecord-session_store.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency('activerecord', '>= 6.1')
   s.add_dependency('actionpack', '>= 6.1')
   s.add_dependency('railties', '>= 6.1')
-  s.add_dependency('rack', '>= 2.0.8', '< 3')
+  s.add_dependency('rack', '>= 2.0.8', '< 4')
   s.add_dependency('multi_json', '~> 1.11', '>= 1.11.2')
 
   s.add_development_dependency('sqlite3')

--- a/lib/active_record/session_store/version.rb
+++ b/lib/active_record/session_store/version.rb
@@ -1,5 +1,5 @@
 module ActiveRecord
   module SessionStore
-    VERSION = "2.0.0".freeze
+    VERSION = "2.0.1".freeze
   end
 end


### PR DESCRIPTION
#198 

We currently have Rack locked at <3 . [Rails actionpack 7.1.0 is slated to support Rack 3.x](https://github.com/rails/rails/pull/46594) . An [early version of this support](https://github.com/rails/rails/commit/859b526c5b9f1e516df3fc1b388c949da3fa9c4e) is already in Rails actionpack 7.1.0.alpha .

I lightly tested the changes with [Rails actionpack 7.1.0.alpha ebba19bb41229f5a431e3bbf15a19c19a61d7464](https://github.com/rails/rails/tree/ebba19bb41229f5a431e3bbf15a19c19a61d7464/actionpack) (2023-05-09) and rack 3.0.7 and did not encounter issues.