### PR TITLE
Call public get_cookie method instead of removed private :hash_for method

### DIFF
--- a/test/action_controller_test.rb
+++ b/test/action_controller_test.rb
@@ -127,7 +127,7 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
       get '/set_session_value'
       assert_response :success
       assert cookies['_session_id']
-      session_cookie = cookies.send(:hash_for)['_session_id']
+      session_cookie = cookies.get_cookie('_session_id')
 
       get '/call_reset_session'
       assert_response :success


### PR DESCRIPTION
👋🏻 Hello!

I ran `bundle exec rake test` against master in a fresh clone and noticed that `ActionControllerTest#test_getting_session_value_after_session_reset` is failing. It looks like this test case calls a private method from rake-test's CookieJar, `:hash_for`, which was removed in https://github.com/rack/rack-test/pull/297 as part of rack-test v2.0.0. I've replaced it with a call to the public `get_cookie` method; it looks like this alternative has been available since [rack-test v0.7.0](https://github.com/rack/rack-test/commit/a519e5615b571d7a34d92c68da5ccfffeef0822c).