### PR TITLE
Fix main branch build

### DIFF
--- a/activerecord-session_store.gemspec
+++ b/activerecord-session_store.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency('railties', '>= 6.1')
   s.add_dependency('rack', '>= 2.0.8', '< 3')
   s.add_dependency('multi_json', '~> 1.11', '>= 1.11.2')
+  s.add_dependency('cgi', '>= 0.3.6')
 
   s.add_development_dependency('sqlite3')
 end

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -6,7 +6,6 @@ git "https://github.com/rails/rails.git", :branch => "main" do
   gem "railties"
 end
 
-gem "rack", :git => "https://github.com/rack/rack.git", :branch => "main"
-gem "rack-session", :git => "https://github.com/rack/rack-session.git", :branch => "main"
+gem "rack", "~> 2.0", ">= 2.2.4"
 
 gemspec :path => "../"

--- a/test/action_controller_test.rb
+++ b/test/action_controller_test.rb
@@ -127,7 +127,7 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
       get '/set_session_value'
       assert_response :success
       assert cookies['_session_id']
-      session_cookie = cookies.send(:hash_for)['_session_id']
+      session_cookie = cookies.get_cookie('_session_id')
 
       get '/call_reset_session'
       assert_response :success


### PR DESCRIPTION
This updates some version requirements and adopts to the api of rack-test 2.

This includes the changes from https://github.com/rails/activerecord-session_store/pull/194