### PR TITLE
Allow ActiveRecordStore.session_class to be evaluated lazily

### DIFF
--- a/test/session_store_test.rb
+++ b/test/session_store_test.rb
@@ -1,0 +1,39 @@
+require "helper"
+require "action_dispatch/session/active_record_store"
+
+module ActionDispatch
+  module Session
+    class ActiveRecordStoreTest < ActiveSupport::TestCase
+
+      class Session < ActiveRecord::SessionStore::Session; end
+
+      def test_session_class_as_string
+        with_session_class("ActionDispatch::Session::ActiveRecordStoreTest::Session") do
+          assert_equal(Session, ActiveRecordStore.session_class)
+        end
+      end
+
+      def test_session_class_as_proc
+        with_session_class(proc { Session }) do
+          assert_equal(Session, ActiveRecordStore.session_class)
+        end
+      end
+
+      def test_session_class_as_class
+        with_session_class(Session) do
+          assert_equal(Session, ActiveRecordStore.session_class)
+        end
+      end
+
+      private
+
+      def with_session_class(klass)
+        old_klass = ActiveRecordStore.session_class
+        ActiveRecordStore.session_class = klass
+        yield
+      ensure
+        ActiveRecordStore.session_class = old_klass
+      end
+    end
+  end
+end


### PR DESCRIPTION
Prevents Active Record from being loaded early in an initializer (where the session_class is being set. This can slow down application boot time.