### PR TITLE
Trimming sessions in batches

### DIFF
--- a/lib/tasks/database.rake
+++ b/lib/tasks/database.rake
@@ -16,6 +16,7 @@ namespace 'db:sessions' do
     cutoff_period = (ENV['SESSION_DAYS_TRIM_THRESHOLD'] || 30).to_i.days.ago
     ActiveRecord::SessionStore::Session.
       where("updated_at < ?", cutoff_period).
+      in_batches.
       delete_all
   end
 


### PR DESCRIPTION
Due to some unforeseen events, we hit the MySQL timeout when trimming our sessions.
We've implemented a batched approach in our own codebase, but I figured this might be beneficial to the gem itself.

Not sure this change warrants any tests (and if so, what the best way is to implement these), so open to suggestions on that.