### PR TITLE
Remove multi_json  as dependency in favor of std-lib json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     name: Ruby ${{ matrix.ruby }} / Rails ${{ matrix.rails }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7', '3.0', '3.1']
-        rails: ['6.1', '7.0', 'edge']
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3']
+        rails: ['6.1', '7.0', '7.1', 'edge']
+        exclude:
+          - ruby: '2.7'
+            rails: 'edge'
+          - ruby: '3.0'
+            rails: 'edge'
     env:
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.gemfile
     name: Ruby ${{ matrix.ruby }} / Rails ${{ matrix.rails }}

--- a/activerecord-session_store.gemspec
+++ b/activerecord-session_store.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.add_dependency('actionpack', '>= 6.1')
   s.add_dependency('railties', '>= 6.1')
   s.add_dependency('rack', '>= 2.0.8', '< 4')
-  s.add_dependency('multi_json', '~> 1.11', '>= 1.11.2')
   s.add_dependency('cgi', '>= 0.3.6')
 
   s.add_development_dependency('sqlite3')

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gem "actionpack", github: "rails/rails", branch: "7-1-stable"
+gem "activerecord", github: "rails/rails", branch: "7-1-stable"
+gem "railties", github: "rails/rails", branch: "7-1-stable"
+gem "rack", ">= 2.2.4", "< 4"
+
+gemspec :path => "../"

--- a/lib/active_record/session_store.rb
+++ b/lib/active_record/session_store.rb
@@ -2,7 +2,7 @@ require 'active_record'
 require 'active_record/session_store/version'
 require 'action_dispatch/session/active_record_store'
 require 'active_support/core_ext/hash/keys'
-require 'multi_json'
+require 'json'
 
 module ActiveRecord
   module SessionStore
@@ -62,12 +62,12 @@ module ActiveRecord
       # Uses built-in JSON library to encode/decode session
       class JsonSerializer
         def self.load(value)
-          hash = MultiJson.load(value)
+          hash = JSON.load(value)
           hash.is_a?(Hash) ? hash.with_indifferent_access[:value] : hash
         end
 
         def self.dump(value)
-          MultiJson.dump(value: value)
+          JSON.dump(value: value)
         end
       end
 

--- a/lib/active_record/session_store.rb
+++ b/lib/active_record/session_store.rb
@@ -62,7 +62,7 @@ module ActiveRecord
       # Uses built-in JSON library to encode/decode session
       class JsonSerializer
         def self.load(value)
-          hash = JSON.load(value)
+          hash = JSON.parse(value)
           hash.is_a?(Hash) ? hash.with_indifferent_access[:value] : hash
         end
 


### PR DESCRIPTION
This PR is almost identical to #212 but for security reasons we want to maintain our own fork.

CI is also updated to include newer Ruby and Rails versions (currently failing on `edge` but that is expected).