### PR TITLE
Improves the trim trask to prevent session fixation.

### DIFF
--- a/lib/tasks/database.rake
+++ b/lib/tasks/database.rake
@@ -15,9 +15,10 @@ namespace 'db:sessions' do
   task :trim => [:environment, 'db:load_config'] do
     cutoff_period = (ENV['SESSION_DAYS_TRIM_THRESHOLD'] || 30).to_i.days.ago
     ActionDispatch::Session::ActiveRecordStore.session_class.
-      where("updated_at < ?", cutoff_period).
-      in_batches.
-      delete_all
+      where("updated_at < ?", cutoff_period).or(
+        ActiveRecord::SessionStore::Session.where("created_at < ?", cutoff_period)
+
+      ).in_batches.delete_all
   end
 
   desc "Upgrade current sessions in the database to the secure version"

--- a/test/tasks/database_rake_test.rb
+++ b/test/tasks/database_rake_test.rb
@@ -40,16 +40,22 @@ module ActiveRecord
           session.updated_at = 5.minutes.until(cutoff_period)
         end
 
+        Session.create!(data: "fixed session") do |session|
+          session.created_at = 5.minutes.until(cutoff_period)
+        end
+
         recent_session = Session.create!(data: "recent") do |session|
           session.updated_at = 5.minutes.since(cutoff_period)
         end
 
         Rake.application.invoke_task 'db:sessions:trim'
 
-        old_session_count = Session.where("updated_at < ?", cutoff_period).count
+        obsolete_session_count = Session.where("updated_at < ?", cutoff_period).count
+        fixed_session_count = Session.where("created_at < ?", cutoff_period).count
         retained_session = Session.find(recent_session.id)
 
-        assert_equal 0, old_session_count
+        assert_equal 0, obsolete_session_count
+        assert_equal 0, fixed_session_count
         assert_equal retained_session, recent_session
       end
 


### PR DESCRIPTION
Removing sessions created before the cutoff period. Otherwise, an attacker could extend the session forever.

It's the Rails guide recommendation: https://guides.rubyonrails.org/security.html#session-fixation-countermeasures