### PR TITLE
Check for a valid encoding before using a public session id

### DIFF
--- a/lib/action_dispatch/session/active_record_store.rb
+++ b/lib/action_dispatch/session/active_record_store.rb
@@ -133,7 +133,7 @@ module ActionDispatch
       end
 
       def get_session_with_fallback(sid)
-        if sid && !self.class.private_session_id?(sid.public_id)
+        if sid && sid.public_id.valid_encoding? && !self.class.private_session_id?(sid.public_id)
           if (secure_session = session_class.find_by_session_id(sid.private_id))
             secure_session
           elsif (insecure_session = session_class.find_by_session_id(sid.public_id))

--- a/test/action_controller_test.rb
+++ b/test/action_controller_test.rb
@@ -237,6 +237,22 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_incorrectly_encoded_session_id_via_cookie_should_be_ignored
+    with_test_route_set do
+      open_session do |sess|
+        incorrectly_encoded_id = "\xAA\xAA".force_encoding('UTF-8')
+        sess.cookies['_session_id'] = incorrectly_encoded_id
+        sess.get '/set_session_value'
+        new_session_id = sess.cookies['_session_id']
+        assert_not_equal incorrectly_encoded_id, new_session_id
+
+        sess.get '/get_session_value'
+        new_session_id_2 = sess.cookies['_session_id']
+        assert_equal new_session_id, new_session_id_2
+      end
+    end
+  end
+
   def test_incoming_invalid_session_id_via_parameter_should_be_ignored
     with_test_route_set(:cookie_only => false) do
       open_session do |sess|


### PR DESCRIPTION
When penetration testing I discovered that if a public session ID contains an invalid byte sequence the following error occurs:
```
Error during failsafe response: invalid byte sequence in UTF-8
/gems/activerecord-session_store-2.1.0/lib/action_dispatch/session/active_record_store.rb:163:in `private_session_id?'
```
This causes an internal server error, when it really should just handle it as an invalid id
