### PR TITLE
Fix tests for newer Rubies/Rails.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,23 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['2.7', '3.0', '3.1', '3.2', '3.3']
-        rails: ['7.0', '7.1', 'edge']
+        rails: ['7.0', '7.1', '7.2', '8.0', 'edge']
         exclude:
+          - ruby: '2.7'
+            rails: '7.2'
+          - ruby: '2.7'
+            rails: '8.0'
           - ruby: '2.7'
             rails: 'edge'
           - ruby: '3.0'
+            rails: '7.2'
+          - ruby: '3.0'
+            rails: '8.0'
+          - ruby: '3.0'
+            rails: 'edge'
+          - ruby: '3.1'
+            rails: '8.0'
+          - ruby: '3.1'
             rails: 'edge'
     env:
       BUNDLE_GEMFILE: gemfiles/rails_${{ matrix.rails }}.gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,9 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 gemspec
 
 gem "sqlite3"
+
+group :development, :test do
+  gem "debug"
+end

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -1,0 +1,11 @@
+source "https://rubygems.org"
+
+gem "actionpack", github: "rails/rails", branch: "7-2-stable"
+gem "activerecord", github: "rails/rails", branch: "7-2-stable"
+gem "railties", github: "rails/rails", branch: "7-2-stable"
+
+gem "rack", ">= 2.2.4", "< 4"
+gem "sqlite3"
+
+gemspec :path => "../"
+

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -1,0 +1,11 @@
+source "https://rubygems.org"
+
+gem "actionpack", github: "rails/rails", branch: "8-0-stable"
+gem "activerecord", github: "rails/rails", branch: "8-0-stable"
+gem "railties", github: "rails/rails", branch: "8-0-stable"
+
+gem "rack", ">= 2.2.4", "< 4"
+gem "sqlite3"
+
+gemspec :path => "../"
+

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,13 +1,14 @@
-require 'bundler/setup'
+require "bundler/setup"
 
-require 'active_record'
-require 'action_controller'
-require 'action_dispatch'
-require 'minitest/autorun'
+require "active_record"
+require "action_controller"
+require "action_dispatch"
+require "debug"
+require "minitest/autorun"
 
-require 'active_record/session_store'
+require "active_record/session_store"
 
-ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
 
 SharedTestRoutes = ActionDispatch::Routing::RouteSet.new
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -21,19 +21,45 @@ module ActionDispatch
   end
 end
 
+class RoutedRackApp
+  class Config < Struct.new(:middleware)
+  end
+
+  attr_reader :routes
+
+  def initialize(routes, &blk)
+    @routes = routes
+    @stack = ActionDispatch::MiddlewareStack.new(&blk)
+    @app = @stack.build(@routes)
+  end
+
+  def call(env)
+    @app.call(env)
+  end
+
+  def config
+    Config.new(@stack)
+  end
+end
+
 class ActionDispatch::IntegrationTest < ActiveSupport::TestCase
   include ActionDispatch::SharedRoutes
 
-  def self.build_app(routes = nil)
+  def self.build_app(routes, options)
     RoutedRackApp.new(routes || ActionDispatch::Routing::RouteSet.new) do |middleware|
       middleware.use ActionDispatch::DebugExceptions
+      middleware.use ActionDispatch::ActionableExceptions
       middleware.use ActionDispatch::Callbacks
       middleware.use ActionDispatch::Cookies
       middleware.use ActionDispatch::Flash
+      middleware.use Rack::MethodOverride
       middleware.use Rack::Head
+      middleware.use ActionDispatch::Session::ActiveRecordStore, options.reverse_merge(key: "_session_id")
       yield(middleware) if block_given?
     end
   end
+
+  self.app = build_app(nil, {})
 
   private
 
@@ -46,10 +72,7 @@ class ActionDispatch::IntegrationTest < ActiveSupport::TestCase
           actions.each { |action| get action, controller: "#{controller_namespace}/test" }
         end
 
-        @app = self.class.build_app(set) do |middleware|
-          middleware.use ActionDispatch::Session::ActiveRecordStore, options.reverse_merge(:key => '_session_id')
-          middleware.delete ActionDispatch::ShowExceptions
-        end
+        self.class.app = self.class.build_app(set, options)
 
         yield
       end
@@ -62,19 +85,6 @@ class ActionDispatch::IntegrationTest < ActiveSupport::TestCase
     ensure
       ActionDispatch::Session::ActiveRecordStore.session_class = session_class
     end
-end
-
-class RoutedRackApp
-  attr_reader :routes
-
-  def initialize(routes, &blk)
-    @routes = routes
-    @stack = ActionDispatch::MiddlewareStack.new(&blk).build(@routes)
-  end
-
-  def call(env)
-    @stack.call(env)
-  end
 end
 
 ActiveSupport::TestCase.test_order = :random

--- a/test/logger_silencer_test.rb
+++ b/test/logger_silencer_test.rb
@@ -39,7 +39,9 @@ class LoggerSilencerTest < ActionDispatch::IntegrationTest
   def test_log_silencer_with_logger_not_raise_exception
     with_logger ActiveSupport::Logger.new(Tempfile.new("tempfile")) do
       with_test_route_set do
-        get "/set_session_value"
+        assert_nothing_raised do
+          get "/set_session_value"
+        end
       end
     end
   end


### PR DESCRIPTION
This add Rails 7.2 and 8.0 to the test matrix. Should we also drop EoL'd Rails/Rubies? For now I've `exclude`d combinations which won't work due to minimum version constraints.

Even then, as of Rail 7.2 the tests for this library are broken. It seems something changed with how `ActionDispatch::Assertions::RoutingAssertions` work as the `reset_routes` method, called by `with_routes`, starts to break because the expected `app` is `nil`.

I've stepped through the code and I'm unsure where that was supposed to be set up, or how it worked back in Rails 7.1. If anyone has pointers, I'm happy to go spelunking and try to get the tests passing so we can consider some of the other PRs to fix various bugs/improvements.