### PR TITLE
Use a test setup similar to `actiondispatch`'s Cookie Store tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,21 +7,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3']
-        rails: ['7.0', '7.1', '7.2', '8.0', 'edge']
+        ruby: ['3.1', '3.2', '3.3']
+        rails: ['7.1', '7.2', '8.0', 'edge']
+        include:
+          - ruby: '2.7'
+            rails: '7.1'
+          - ruby: '3.0'
+            rails: '7.1'
         exclude:
-          - ruby: '2.7'
-            rails: '7.2'
-          - ruby: '2.7'
-            rails: '8.0'
-          - ruby: '2.7'
-            rails: 'edge'
-          - ruby: '3.0'
-            rails: '7.2'
-          - ruby: '3.0'
-            rails: '8.0'
-          - ruby: '3.0'
-            rails: 'edge'
           - ruby: '3.1'
             rails: '8.0'
           - ruby: '3.1'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Drop Rails 7.0 support.
+
 ## 2.2.0
 
 * Drop dependency on `multi_json`.

--- a/activerecord-session_store.gemspec
+++ b/activerecord-session_store.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w( README.md )
   s.rdoc_options.concat ['--main',  'README.md']
 
-  s.add_dependency('activerecord', '>= 7.0')
-  s.add_dependency('actionpack', '>= 7.0')
-  s.add_dependency('railties', '>= 7.0')
+  s.add_dependency('activerecord', '>= 7.1')
+  s.add_dependency('actionpack', '>= 7.1')
+  s.add_dependency('railties', '>= 7.1')
   s.add_dependency('rack', '>= 2.0.8', '< 4')
   s.add_dependency('cgi', '>= 0.3.6')
 end

--- a/activerecord-session_store.gemspec
+++ b/activerecord-session_store.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.version     = ActiveRecord::SessionStore::VERSION
   s.summary     = 'An Action Dispatch session store backed by an Active Record class.'
 
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.7.0'
   s.license     = 'MIT'
 
   s.author      = 'David Heinemeier Hansson'

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -1,9 +1,0 @@
-source "https://rubygems.org"
-
-gem "actionpack", github: "rails/rails", branch: "6-1-stable"
-gem "activerecord", github: "rails/rails", branch: "6-1-stable"
-gem "railties", github: "rails/rails", branch: "6-1-stable"
-gem "rack", "< 3"
-gem "sqlite3", "~> 1.4"
-
-gemspec :path => "../"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -1,9 +1,0 @@
-source "https://rubygems.org"
-
-gem "actionpack", github: "rails/rails", branch: "7-0-stable"
-gem "activerecord", github: "rails/rails", branch: "7-0-stable"
-gem "railties", github: "rails/rails", branch: "7-0-stable"
-gem "rack", "< 3"
-gem "sqlite3", "~> 1.4"
-
-gemspec :path => "../"

--- a/test/action_controller_test.rb
+++ b/test/action_controller_test.rb
@@ -197,7 +197,9 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_allows_session_fixation
-    with_test_route_set(:cookie_only => false) do
+    session_options(cookie_only: false)
+
+    with_test_route_set do
       get '/set_session_value'
       assert_response :success
       assert cookies['_session_id']
@@ -238,7 +240,9 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_incoming_invalid_session_id_via_parameter_should_be_ignored
-    with_test_route_set(:cookie_only => false) do
+    session_options(cookie_only: false)
+
+    with_test_route_set do
       open_session do |sess|
         sess.get '/set_session_value', :params => { :_session_id => 'INVALID' }
         new_session_id = sess.cookies['_session_id']
@@ -252,7 +256,9 @@ class ActionControllerTest < ActionDispatch::IntegrationTest
   end
 
   def test_session_store_with_all_domains
-    with_test_route_set(:domain => :all) do
+    session_options(domain: :all)
+
+    with_test_route_set do
       get '/set_session_value'
       assert_response :success
     end

--- a/test/with_integration_routing_patch.rb
+++ b/test/with_integration_routing_patch.rb
@@ -1,0 +1,62 @@
+# Bring with_routing method support for integration tests back to Rails 7.1.
+# We can remove this when we drop support for Rails 7.1.
+# See: https://github.com/rails/rails/pull/49819
+module WithIntegrationRoutingPatch # :nodoc:
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def with_routing(&block)
+      old_routes = nil
+      old_integration_session = nil
+
+      setup do
+        old_routes = app.routes
+        old_integration_session = integration_session
+        create_routes(&block)
+      end
+
+      teardown do
+        reset_routes(old_routes, old_integration_session)
+      end
+    end
+  end
+
+  def with_routing(&block)
+    old_routes = app.routes
+    old_integration_session = integration_session
+    create_routes(&block)
+  ensure
+    reset_routes(old_routes, old_integration_session)
+  end
+
+  private
+
+  def create_routes
+    app = self.app
+    routes = ActionDispatch::Routing::RouteSet.new
+    rack_app = app.config.middleware.build(routes)
+    https = integration_session.https?
+    host = integration_session.host
+
+    app.instance_variable_set(:@routes, routes)
+    app.instance_variable_set(:@app, rack_app)
+    @integration_session = Class.new(ActionDispatch::Integration::Session) do
+      include app.routes.url_helpers
+      include app.routes.mounted_helpers
+    end.new(app)
+    @integration_session.https! https
+    @integration_session.host! host
+    @routes = routes
+
+    yield routes
+  end
+
+  def reset_routes(old_routes, old_integration_session)
+    old_rack_app = app.config.middleware.build(old_routes)
+
+    app.instance_variable_set(:@routes, old_routes)
+    app.instance_variable_set(:@app, old_rack_app)
+    @integration_session = old_integration_session
+    @routes = old_routes
+  end
+end


### PR DESCRIPTION
I took another look at the changes we had to make in #220 and compared that to how things work in `actiondispatch`'s Cookie Store tests and realized we were close, but missing how we were setting the options for our store. So I've revamped the setup to be in line with what's in Rails' own tests. This should make it easier to keep things in line and working, going forward.

See the following two files for how Cookie Store tests (and their base `ActionDispatch::IntegrationTest`) work today (as of Rails 8.0):
   * https://github.com/rails/rails/blob/8-0-stable/actionpack/test/dispatch/session/cookie_store_test.rb
   * https://github.com/rails/rails/blob/8-0-stable/actionpack/test/abstract_unit.rb

The big downside to this is… it depends on some changes to how `#with_routing`, provided by Rails, works. Meaning it only works with Rails 7.2+. ☹️