### PR TITLE
Add config to disable sessid column fallback

### DIFF
--- a/lib/active_record/session_store.rb
+++ b/lib/active_record/session_store.rb
@@ -8,6 +8,9 @@ module ActiveRecord
   module SessionStore
     autoload :Session, 'active_record/session_store/session'
 
+    @disable_sessid_fallback = false
+    singleton_class.attr_accessor :disable_sessid_fallback
+
     module ClassMethods # :nodoc:
       mattr_accessor :serializer
 


### PR DESCRIPTION
I'm working on removing queries in my application that should be going through the SchemaCache in production but currently are not. I found that the `sessions` table is being queried during runtime due to the `reset_column_information` when the class is loaded (which clears the SchemaCache for the `sessions` table).

This commit introduces a new configuration to disable the `sessid` column fallback (which is the source of the `reset_column_information`).

Since the `session_id` -> `sessid` fallback has been in place for [twenty years][1], there may be an argument to just remove it, but this gem is very very stable so breaking changes should probably be held to an even higher threshold.

[1]: https://github.com/rails/rails/commit/452442dde8e8ea5949c387ea5c78387bff330f2a