### PR TITLE
ci: scope ci workflow token to contents: read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This narrows the `GITHUB_TOKEN` for `.github/workflows/ci.yml` to read-only.

- These jobs only check out the repo and run build/test steps, so `contents: read` covers them.
- Without an explicit block the token inherits the repo default, often write-enabled.
- Following the principle of least privilege from the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token).

Behavior is unchanged.