### PR TITLE
use `session_class` in database tasks

### DIFF
--- a/lib/tasks/database.rake
+++ b/lib/tasks/database.rake
@@ -16,7 +16,7 @@ namespace 'db:sessions' do
     cutoff_period = (ENV['SESSION_DAYS_TRIM_THRESHOLD'] || 30).to_i.days.ago
     ActionDispatch::Session::ActiveRecordStore.session_class.
       where("updated_at < ?", cutoff_period).or(
-        ActiveRecord::SessionStore::Session.where("created_at < ?", cutoff_period)
+        ActionDispatch::Session::ActiveRecordStore.session_class.where("created_at < ?", cutoff_period)
 
       ).in_batches.delete_all
   end


### PR DESCRIPTION
@rafaelfranca BTW I believe this can be simplfied to only `where( created_at  < ?, cutoff_period)`

the example in the rails guides, uses a different period for each column `where(updated_at: ...time.ago).or(where(created_at: ...2.days.ago)).delete_all)`  ( check : https://guides.rubyonrails.org/security.html#session-expiry )

I'm in favor of only keeping `created_at` and adding an index on that column instead of an index on `updated_at` because adding an index on `updated_at` ( a column which is constantly/naturally updated almost every single time) prevents Heap Only Tuple (HOT ) updates on PostgreSQL, which can lead to write amplification / more WAL etc...

